### PR TITLE
Phase 1: stability, alignment, API-version discovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,102 @@
+name: Release Chrome Extension
+
+# Triggers:
+#   1. Pushing a tag of the form vX.Y.Z — the canonical release path.
+#   2. Manually via the Actions tab (workflow_dispatch) — useful for testing
+#      the packaging without publishing; the run still creates the release,
+#      so prefer tag-push in practice.
+#
+# The workflow refuses to proceed unless manifest.json's version matches the
+# tag, so we can't accidentally ship a mislabelled zip.
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to package (e.g. 3.0.3). Tag v<version> must already exist, or will be created from the current branch.'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Package and publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Determine version and tag
+        id: ver
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            tag="${GITHUB_REF_NAME}"
+            version="${tag#v}"
+          else
+            version="${{ github.event.inputs.version }}"
+            tag="v${version}"
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "Resolved version=${version}, tag=${tag}"
+
+      - name: Verify manifest version matches tag
+        run: |
+          set -euo pipefail
+          manifest_version=$(python3 -c "import json,sys;print(json.load(open('manifest.json'))['version'])")
+          expected="${{ steps.ver.outputs.version }}"
+          if [[ "${manifest_version}" != "${expected}" ]]; then
+            echo "::error::manifest.json version is '${manifest_version}' but the release is '${expected}'. Bump manifest.json before tagging."
+            exit 1
+          fi
+          echo "manifest.json version matches: ${manifest_version}"
+
+      - name: Package extension (whitelist only what ships)
+        id: pkg
+        run: |
+          set -euo pipefail
+          # Whitelist. Anything outside this list (screenshots, marketing PNGs,
+          # IDE config, *.md, .git, .github) stays out of the Chrome Web Store
+          # zip so reviewers don't see dev cruft.
+          zipname="change-set-helper-ext-${{ steps.ver.outputs.tag }}.zip"
+          zip -r "${zipname}" \
+            manifest.json \
+            background.js \
+            offscreen.html offscreen.js \
+            changeset.js changeview.js \
+            deployhelper.js metadatahelper.js \
+            common.js \
+            compare.js compare.html \
+            options.html options.js \
+            popup.html \
+            changeset.css \
+            lib \
+            brainbulb128.png brainbulb48.png braincloudsmall.png \
+            loading.gif
+          ls -lh "${zipname}"
+          echo "zipname=${zipname}" >> "$GITHUB_OUTPUT"
+
+      - name: Create or update GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="${{ steps.ver.outputs.tag }}"
+          zipname="${{ steps.pkg.outputs.zipname }}"
+          # If triggered via workflow_dispatch, the tag may not exist yet.
+          if ! git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+            git tag "${tag}"
+            git push origin "${tag}"
+          fi
+          if gh release view "${tag}" >/dev/null 2>&1; then
+            gh release upload "${tag}" "${zipname}" --clobber
+          else
+            gh release create "${tag}" "${zipname}" \
+              --title "${tag}" \
+              --generate-notes
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 # Claude Code files
 CLAUDE.md
 .claude/
+.remember/
+
+# Local build output
+change-set-helper-ext-*.zip

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Salesforce Change Set Helper Reloaded
 
-![Version](https://img.shields.io/badge/version-3.0.2-blue.svg)
+![Version](https://img.shields.io/badge/version-3.0.3-blue.svg)
 ![Manifest](https://img.shields.io/badge/manifest-v3-green.svg)
 ![License](https://img.shields.io/badge/license-MIT-orange.svg)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Salesforce Change Set Helper Reloaded
 
-![Version](https://img.shields.io/badge/version-3.0.1-blue.svg)
+![Version](https://img.shields.io/badge/version-3.0.2-blue.svg)
 ![Manifest](https://img.shields.io/badge/manifest-v3-green.svg)
 ![License](https://img.shields.io/badge/license-MIT-orange.svg)
 

--- a/background.js
+++ b/background.js
@@ -2,19 +2,41 @@
 // JSforce operations are handled in offscreen.html/offscreen.js due to XMLHttpRequest requirement
 
 var CSH_APIVERSION = "60.0";
+var CSH_APIVERSION_IS_USER_PREF = false;
 const versionPattern = RegExp('^[0-9][0-9]\.0$');
 
-chrome.storage.sync.get(['salesforceApiVersion'], function(items) {
-    if (items.salesforceApiVersion) {
-        CSH_APIVERSION = versionPattern.test(items.salesforceApiVersion) ? items.salesforceApiVersion : '60.0';
-        console.log('Service Worker - API Version:', CSH_APIVERSION);
+// Priority:
+//   1. chrome.storage.sync.salesforceApiVersion  — user-set from options page
+//   2. chrome.storage.local.cshResolvedApiVersion — auto-discovered by common.js
+//   3. fallback "60.0"
+function applyApiVersion(value, isUserPref) {
+    if (value && versionPattern.test(value)) {
+        CSH_APIVERSION = value;
+        CSH_APIVERSION_IS_USER_PREF = !!isUserPref;
+        console.log('Service Worker - API Version:', CSH_APIVERSION, isUserPref ? '(user pref)' : '(auto)');
     }
+}
+
+chrome.storage.sync.get(['salesforceApiVersion'], function (items) {
+    if (items && items.salesforceApiVersion) {
+        applyApiVersion(items.salesforceApiVersion, true);
+        return;
+    }
+    // No user pref — fall back to the auto-detected value if one is cached.
+    chrome.storage.local.get(['cshResolvedApiVersion'], function (local) {
+        if (local && local.cshResolvedApiVersion) {
+            applyApiVersion(local.cshResolvedApiVersion, false);
+        }
+    });
 });
 
 chrome.storage.onChanged.addListener(function (changes, areaName) {
-    if (changes.salesforceApiVersion) {
-        CSH_APIVERSION = versionPattern.test(changes.salesforceApiVersion.newValue) ? changes.salesforceApiVersion.newValue : '60.0';
-        console.log('Service Worker - API Version changed:', CSH_APIVERSION);
+    if (areaName === 'sync' && changes.salesforceApiVersion) {
+        applyApiVersion(changes.salesforceApiVersion.newValue, true);
+        return;
+    }
+    if (areaName === 'local' && changes.cshResolvedApiVersion && !CSH_APIVERSION_IS_USER_PREF) {
+        applyApiVersion(changes.cshResolvedApiVersion.newValue, false);
     }
 });
 

--- a/changeset.js
+++ b/changeset.js
@@ -79,26 +79,43 @@ var entityFolderMap = {
 }
 
 
-// Helper function to add columns to specific rows (avoids freezing with large datasets)
+// Remembered once in setupTable() so every row/column index is computed from
+// Salesforce's actual DOM instead of a hard-coded 1-or-2 guess. Lets the
+// extension work on entity types where Salesforce renders Name+Type+Parent
+// (CustomField, WorkflowFieldUpdate, RecordType, etc.) instead of only Name.
+var cshOriginalRowCellCount = null;    // max <td> count per tr.dataRow before we touched the table
+var cshOriginalHeaderCount = null;     // <th>+<td> count in tr.headerRow before we touched it
+
+function cshExtraColumnsPerRow() {
+    var dyn = (dynamicColumns && dynamicColumns.length > 0) ? dynamicColumns.length : 3;
+    return dyn + 4; // dynamic + 4 compare columns
+}
+
+// Helper function to add columns to specific rows (avoids freezing with large datasets).
+// Two-pass strategy: first find the widest existing row, then pad every row up to
+// (widest + extraColumns). Prevents ragged rows when Salesforce renders some rows
+// without the Type column (happens for heterogeneous folder-based types).
 function addColumnsToRows(rows) {
-    // Add dynamic columns based on metadata properties
-    // Use empty string since applyMetadataToRows() will immediately populate with actual values
-    if (dynamicColumns && dynamicColumns.length > 0) {
-        for (var i = 0; i < dynamicColumns.length; i++) {
-            rows.append("<td></td>"); // Will be populated by applyMetadataToRows
-        }
-    } else {
-        // Fallback to basic columns if metadata not loaded yet (should not happen in normal flow)
-        rows.append("<td></td>"); // Full Name
-        rows.append("<td></td>"); // Last Modified Date
-        rows.append("<td></td>"); // Last Modified By Name
+    if (!rows || rows.length === 0) return;
+
+    var extra = cshExtraColumnsPerRow();
+    var widest = 0;
+    rows.each(function () {
+        var c = $(this).children('td').length;
+        if (c > widest) widest = c;
+    });
+    if (cshOriginalRowCellCount === null) {
+        cshOriginalRowCellCount = widest;
+    } else if (widest > cshOriginalRowCellCount) {
+        cshOriginalRowCellCount = widest;
     }
 
-    // Add compare columns (empty initially, populated when compare is clicked)
-    rows.append("<td></td>"); // Folder
-    rows.append("<td></td>"); // Compare Date Modified
-    rows.append("<td></td>"); // Compare Modified By
-    rows.append("<td></td>"); // Full Name (for diff)
+    var target = cshOriginalRowCellCount + extra;
+    rows.each(function () {
+        var row = $(this);
+        var have = row.children('td').length;
+        for (var i = have; i < target; i++) row.append('<td></td>');
+    });
 }
 
 function setupTable() {
@@ -110,6 +127,21 @@ function setupTable() {
 
     console.log('setupTable: Type column exists:', typeColumn.length > 0);
     console.log('setupTable: Name column exists:', nameColumn.length > 0);
+
+    // Snapshot the ORIGINAL cell counts before we mutate the table. Every
+    // subsequent column-index computation keys off these values, which keeps
+    // the extension correct for any entity type Salesforce decides to render —
+    // including types that add a parent-object column (CustomField, Workflow*,
+    // RecordType, ListView, CompactLayout) and ones that drop the Type column.
+    cshOriginalHeaderCount = $("table.list tr.headerRow").children('th,td').length;
+    var widestDataRow = 0;
+    $("table.list tr.dataRow").each(function () {
+        var c = $(this).children('td').length;
+        if (c > widestDataRow) widestDataRow = c;
+    });
+    cshOriginalRowCellCount = widestDataRow;
+    console.log('setupTable: original header cells =', cshOriginalHeaderCount,
+                ', widest data row =', widestDataRow);
 
     // Log original header structure
     var originalHeaders = [];
@@ -246,16 +278,25 @@ function isSalesforceId(value) {
     return /^[a-zA-Z0-9]+$/.test(value);
 }
 
-// Determine which columns to add dynamically based on metadata properties
-function determineMetadataColumns(metadataRecord) {
-    if (!metadataRecord) {
+// Determine which columns to add dynamically based on metadata properties.
+// Accepts either a single record or an array; for an array we union properties
+// across all records so heterogeneous results (e.g. managed-package records
+// with extra fields) don't silently drop columns that only some rows carry.
+function determineMetadataColumns(metadataRecordOrArray) {
+    if (!metadataRecordOrArray) {
         console.log('determineMetadataColumns: No metadata record provided');
         return [];
     }
 
+    var records = Array.isArray(metadataRecordOrArray) ? metadataRecordOrArray : [metadataRecordOrArray];
+    records = records.filter(function (r) { return r && typeof r === 'object'; });
+    if (records.length === 0) {
+        console.log('determineMetadataColumns: No usable records');
+        return [];
+    }
+
     console.log('========================================');
-    console.log('determineMetadataColumns: Analyzing metadata properties');
-    console.log('Sample metadata record:', metadataRecord);
+    console.log('determineMetadataColumns: Analyzing', records.length, 'record(s) for column union');
 
     var columns = [];
 
@@ -274,47 +315,56 @@ function determineMetadataColumns(metadataRecord) {
         'lastModifiedByName'
     ];
 
-    // First add properties in preferred order if they exist
+    function propertyIsUsable(prop) {
+        // Scan up to the first 25 records: a property is "usable" when any one
+        // of them holds a non-ID, defined value. This tolerates records with
+        // sparse metadata (managed packages, older components).
+        var limit = Math.min(records.length, 25);
+        for (var r = 0; r < limit; r++) {
+            var rec = records[r];
+            if (rec && rec.hasOwnProperty(prop) && rec[prop] !== undefined && rec[prop] !== null && rec[prop] !== '') {
+                if (isSalesforceId(rec[prop])) continue;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // First add properties in preferred order if any record exposes them
     for (var i = 0; i < propertyOrder.length; i++) {
         var prop = propertyOrder[i];
-        console.log('  - Checking property:', prop, 'exists:', metadataRecord.hasOwnProperty(prop), 'value:', metadataRecord[prop]);
-
-        if (metadataRecord.hasOwnProperty(prop) && metadataRecord[prop] !== undefined) {
-            // Skip if the value is a Salesforce ID
-            if (isSalesforceId(metadataRecord[prop])) {
-                console.log('    → Skipping (Salesforce ID format)');
-                continue;
-            }
-
-            console.log('    → Adding column:', prop);
+        if (propertyIsUsable(prop)) {
+            console.log('    → Adding preferred column:', prop);
             columns.push({
                 propertyName: prop,
                 headerLabel: camelCaseToCapitalCase(prop),
                 isDate: prop.toLowerCase().includes('date')
             });
         } else {
-            console.log('    → Property not found or undefined');
+            console.log('    → Skipping preferred column (not present on any scanned record):', prop);
         }
     }
 
-    // Then add any remaining properties not already included
-    for (var prop in metadataRecord) {
-        if (metadataRecord.hasOwnProperty(prop) &&
-            skipProperties.indexOf(prop) === -1 &&
-            propertyOrder.indexOf(prop) === -1 &&
-            metadataRecord[prop] !== undefined) {
-
-            // Skip if the value is a Salesforce ID
-            if (isSalesforceId(metadataRecord[prop])) {
-                console.log('  - Skipping column', prop, '(Salesforce ID format)');
-                continue;
-            }
+    // Then union any remaining properties across all scanned records.
+    var seen = {};
+    columns.forEach(function (c) { seen[c.propertyName] = true; });
+    var scanLimit = Math.min(records.length, 25);
+    for (var r = 0; r < scanLimit; r++) {
+        var rec = records[r];
+        if (!rec) continue;
+        for (var prop in rec) {
+            if (!rec.hasOwnProperty(prop)) continue;
+            if (seen[prop]) continue;
+            if (skipProperties.indexOf(prop) !== -1) continue;
+            if (propertyOrder.indexOf(prop) !== -1) continue;
+            if (!propertyIsUsable(prop)) continue;
 
             columns.push({
                 propertyName: prop,
                 headerLabel: camelCaseToCapitalCase(prop),
                 isDate: prop.toLowerCase().includes('date')
             });
+            seen[prop] = true;
         }
     }
 
@@ -353,10 +403,10 @@ function processListResults(response) {
             console.log('Second JSforce result:', results[1]);
         }
 
-        // Determine dynamic columns from first metadata record (only once)
+        // Determine dynamic columns from the union of all records (only once)
         var isFirstTime = !dynamicColumns;
         if (isFirstTime && results[0]) {
-            dynamicColumns = determineMetadataColumns(results[0]);
+            dynamicColumns = determineMetadataColumns(results);
             console.log('Dynamic columns determined:', dynamicColumns.length, 'columns');
 
             // Setup table structure with dynamic columns (first time only)
@@ -456,12 +506,13 @@ function applyMetadataToRows(results) {
 
         var row = matchingInput.first().closest('tr');
 
-        // Calculate the starting column index for dynamic columns in row cells
-        // Row td cells: Name(0), EmptyType(1), Dynamic columns(2+)
-        // Note: Checkbox is in header but not in row td's
-        // Calculate base column count based on whether Type column exists
-        // Row structure: Name(td-0), [Type(td-1) if exists], Dynamic columns
-        var baseColumnCount = typeColumn.length > 0 ? 2 : 1;
+        // Dynamic columns start AFTER every cell Salesforce originally rendered
+        // in this row (Name + optional Type + optional ParentObject + ...).
+        // Using cshOriginalRowCellCount keeps alignment correct regardless of
+        // how many columns the entity type actually emits.
+        var baseColumnCount = (typeof cshOriginalRowCellCount === 'number' && cshOriginalRowCellCount > 0)
+            ? cshOriginalRowCellCount
+            : (typeColumn.length > 0 ? 2 : 1);
 
         // Log first row update
         if (i === 0) {
@@ -646,23 +697,21 @@ function createDataTable() {
         }
     }
 
-    // Build dynamic column configuration
-    // Salesforce header includes checkbox column, so DataTables needs to know about it
-    // Header structure depends on whether Type column exists:
-    // - If Type exists: Checkbox(0), Name(1), Type(2), Dynamic columns(3+)
-    // - If Type doesn't exist: Checkbox(0), Name(1), Dynamic columns(2+)
-    var columnConfig = [
-        {"searchable": false, "orderable": false, "targets": 0}, //0: checkbox (in header but not in row tds)
-        null, //1: name
-    ];
+    // Build dynamic column configuration from the header baseline captured by
+    // setupTable(). The first header cell is always the checkbox (searchable:
+    // false, orderable: false). Every subsequent original header cell — Name,
+    // Type, Parent Object, etc. — becomes a plain text column.
+    var baseColumnCount = (typeof cshOriginalHeaderCount === 'number' && cshOriginalHeaderCount > 0)
+        ? cshOriginalHeaderCount
+        : (typeColumn.length > 0 ? 3 : 2);
 
-    // Add Type column to config only if it exists in the DOM
-    if (typeColumn.length > 0) {
-        columnConfig.push(null); //2: type
+    var columnConfig = [];
+    // Column 0: the Salesforce checkbox header (no row-level <td>, DataTables still accounts for it)
+    columnConfig.push({ searchable: false, orderable: false });
+    // Columns 1..baseColumnCount-1: Name + whatever other base columns Salesforce rendered
+    for (var base = 1; base < baseColumnCount; base++) {
+        columnConfig.push(null);
     }
-
-    // Calculate base column count for dynamic column indices
-    var baseColumnCount = typeColumn.length > 0 ? 3 : 2; // checkbox, name, [optional type]
 
     // Find the column to order by (default to first date column)
     var orderByColumnIndex = baseColumnCount; // Default to first dynamic column
@@ -787,9 +836,11 @@ function basicTableInitComplete() {
  When the list table is added, these functionas are added to the make the columns searchable and selectable.
  **/
 function tableInitComplete() {
-    // Calculate the starting index for dynamic columns based on whether Type exists
-    // Column structure: Checkbox(0), Name(1), [Type(2) if exists], Dynamic columns
-    var dynamicColumnsStartIndex = typeColumn.length > 0 ? 3 : 2;
+    // Dynamic columns start after the checkbox + every original header cell.
+    // cshOriginalHeaderCount already counts the checkbox, so it IS the start.
+    var dynamicColumnsStartIndex = (typeof cshOriginalHeaderCount === 'number' && cshOriginalHeaderCount > 0)
+        ? cshOriginalHeaderCount
+        : (typeColumn.length > 0 ? 3 : 2);
 
     this.api().columns().every(function () {
         var column = this;
@@ -809,12 +860,12 @@ function tableInitComplete() {
             shouldAddFilter = true;
             useTextSearch = true;
         }
-        // Column 2: Type - dropdown (only if Type column exists)
-        else if (colIndex === 2 && typeColumn.length > 0) {
+        // Columns 2..dynamicColumnsStartIndex-1: Type / Parent Object / etc. -> dropdown
+        else if (colIndex > 1 && colIndex < dynamicColumnsStartIndex) {
             shouldAddFilter = true;
             useDropdown = true;
         }
-        // Dynamic columns (starting at 2 or 3 depending on Type)
+        // Dynamic columns (starting at dynamicColumnsStartIndex)
         else if (colIndex >= dynamicColumnsStartIndex && dynamicColumns) {
             var dynamicColIndex = colIndex - dynamicColumnsStartIndex; // Subtract base columns
             if (dynamicColIndex < dynamicColumns.length) {
@@ -1065,8 +1116,11 @@ if (selectedEntityType in entityTypeMap) {
         if (chrome.runtime.lastError) {
             console.error('OAuth connection failed:', chrome.runtime.lastError);
             $('#csh-loading-overlay').remove();
-            alert('Failed to connect to Salesforce. Please refresh the page and try again.\n\nError: ' +
-                  chrome.runtime.lastError.message);
+            window.cshToast && window.cshToast.show(
+                'Failed to connect to Salesforce. Please refresh the page and try again.\n\nError: ' +
+                chrome.runtime.lastError.message,
+                { type: 'error' }
+            );
             $("#editPage").removeClass("lowOpacity");
             $("#bodyCell").removeClass("changesetloading");
             return;
@@ -1076,7 +1130,10 @@ if (selectedEntityType in entityTypeMap) {
         if (response && response.error) {
             console.error('OAuth connection failed:', response.error);
             $('#csh-loading-overlay').remove();
-            alert('Failed to connect to Salesforce. Please refresh the page and try again.\n\nError: ' + response.error);
+            window.cshToast && window.cshToast.show(
+                'Failed to connect to Salesforce. Please refresh the page and try again.\n\nError: ' + response.error,
+                { type: 'error' }
+            );
             $("#editPage").removeClass("lowOpacity");
             $("#bodyCell").removeClass("changesetloading");
             return;
@@ -1114,7 +1171,10 @@ if (selectedEntityType in entityTypeMap) {
         } catch (error) {
             console.error('Error during metadata fetch:', error);
             $('#csh-loading-overlay').remove();
-            alert('An error occurred while fetching metadata. Please try again.\n\nError: ' + error.message);
+            window.cshToast && window.cshToast.show(
+                'An error occurred while fetching metadata. Please try again.\n\nError: ' + error.message,
+                { type: 'error' }
+            );
             $("#editPage").removeClass("lowOpacity");
             $("#bodyCell").removeClass("changesetloading");
         }
@@ -1329,7 +1389,11 @@ function startPaginationWithMetadata() {
 
             } catch (error) {
                 console.error("Error fetching page:", error);
-                alert("Error loading page " + (currentPage + 1) + ". Table will display " + totalRowsLoaded + " rows loaded so far.");
+                window.cshToast && window.cshToast.show(
+                    "Error loading page " + (currentPage + 1) +
+                    ". Table will display " + totalRowsLoaded + " rows loaded so far.",
+                    { type: 'warning' }
+                );
                 shouldContinuePagination = false;
                 isLoadingMorePages = false; // Mark as complete
 

--- a/common.js
+++ b/common.js
@@ -1,3 +1,227 @@
-var sessionId = document.cookie.match('sid=([^;]*)')[1];
-var serverUrl  = window.location.protocol + "//" + window.location.host;
+// ---------------------------------------------------------------------------
+// Change Set Helper — shared runtime
+// Loaded BEFORE every page-specific script (changeset.js, deployhelper.js, etc.)
+// so we have a single place to do jQuery isolation, toast UI, and API-version
+// discovery.
+// ---------------------------------------------------------------------------
 
+// 1) jQuery isolation.
+//    Even though content scripts live in their own "isolated world" and do not
+//    normally leak jQuery into Salesforce's page context, calling noConflict
+//    here is cheap defensive hardening: it guarantees we never clobber a $ /
+//    jQuery that some other well-intentioned extension also injected.
+//    We re-attach to window so every script that loads after us still sees $.
+if (typeof window !== 'undefined' && window.jQuery && typeof window.jQuery.noConflict === 'function') {
+    try {
+        var __cshJQ = window.jQuery.noConflict(true);
+        window.$ = __cshJQ;
+        window.jQuery = __cshJQ;
+        window.cshJQ = __cshJQ;
+    } catch (e) {
+        // If noConflict is unavailable for any reason, fall back to whatever $ is present.
+        console.warn('Change Set Helper: jQuery.noConflict failed, continuing with default $', e);
+    }
+}
+
+// 2) Session context — unchanged from the original extension.
+var sessionId = (function () {
+    var m = document.cookie.match('sid=([^;]*)');
+    return m ? m[1] : null;
+})();
+var serverUrl = window.location.protocol + '//' + window.location.host;
+
+// 3) Lightweight SLDS-styled toast, used in place of alert().
+//    window.cshToast.show(message, { type: 'error' | 'warning' | 'success' | 'info', duration })
+(function () {
+    var COLOURS = {
+        error:   { bg: '#ba0517', fg: '#ffffff', border: '#8e0916' },
+        warning: { bg: '#fe9339', fg: '#1b1b1b', border: '#d5721c' },
+        success: { bg: '#2e844a', fg: '#ffffff', border: '#22633a' },
+        info:    { bg: '#0176d3', fg: '#ffffff', border: '#014486' }
+    };
+
+    function ensureStage() {
+        var stage = document.getElementById('csh-toast-stage');
+        if (!stage) {
+            stage = document.createElement('div');
+            stage.id = 'csh-toast-stage';
+            stage.style.cssText = [
+                'position:fixed',
+                'top:16px',
+                'right:16px',
+                'z-index:2147483646',
+                'display:flex',
+                'flex-direction:column',
+                'gap:8px',
+                'pointer-events:none',
+                'max-width:min(480px, 90vw)'
+            ].join(';');
+            document.body.appendChild(stage);
+        }
+        return stage;
+    }
+
+    function show(message, opts) {
+        opts = opts || {};
+        var type = COLOURS[opts.type] ? opts.type : 'info';
+        var palette = COLOURS[type];
+        var duration = typeof opts.duration === 'number' ? opts.duration : (type === 'error' ? 0 : 6000);
+
+        var stage = ensureStage();
+        var toast = document.createElement('div');
+        toast.style.cssText = [
+            'background:' + palette.bg,
+            'color:' + palette.fg,
+            'border:1px solid ' + palette.border,
+            'border-radius:4px',
+            'padding:12px 14px',
+            'font:13px/1.4 "Salesforce Sans", Arial, sans-serif',
+            'box-shadow:0 2px 8px rgba(0,0,0,0.25)',
+            'display:flex',
+            'align-items:flex-start',
+            'gap:10px',
+            'pointer-events:auto',
+            'opacity:0',
+            'transform:translateY(-4px)',
+            'transition:opacity 160ms ease, transform 160ms ease'
+        ].join(';');
+
+        var icon = document.createElement('span');
+        icon.setAttribute('aria-hidden', 'true');
+        icon.style.cssText = 'flex:0 0 auto;font-weight:700;line-height:1;padding-top:1px;';
+        icon.textContent = type === 'error' ? '⛔' : type === 'warning' ? '⚠️' : type === 'success' ? '✔' : 'ℹ';
+
+        var body = document.createElement('div');
+        body.style.cssText = 'flex:1 1 auto;white-space:pre-wrap;word-break:break-word;';
+        body.textContent = String(message);
+
+        var close = document.createElement('button');
+        close.type = 'button';
+        close.setAttribute('aria-label', 'Dismiss notification');
+        close.textContent = '×';
+        close.style.cssText = [
+            'flex:0 0 auto',
+            'background:transparent',
+            'border:0',
+            'color:inherit',
+            'font-size:18px',
+            'line-height:1',
+            'cursor:pointer',
+            'padding:0 4px'
+        ].join(';');
+
+        toast.appendChild(icon);
+        toast.appendChild(body);
+        toast.appendChild(close);
+        stage.appendChild(toast);
+
+        requestAnimationFrame(function () {
+            toast.style.opacity = '1';
+            toast.style.transform = 'translateY(0)';
+        });
+
+        function dismiss() {
+            toast.style.opacity = '0';
+            toast.style.transform = 'translateY(-4px)';
+            setTimeout(function () {
+                if (toast.parentNode) toast.parentNode.removeChild(toast);
+            }, 180);
+        }
+
+        close.addEventListener('click', dismiss);
+        if (duration > 0) setTimeout(dismiss, duration);
+        return { dismiss: dismiss };
+    }
+
+    window.cshToast = { show: show };
+})();
+
+// 4) Dynamic Salesforce API version discovery.
+//    Hits /services/data/ on the current host and picks the highest supported
+//    version. Cached per-host in chrome.storage.local for 24h so we don't
+//    round-trip every page load. Falls back to stored sync pref, then to 60.0.
+(function () {
+    var FALLBACK = '60.0';
+    var CACHE_KEY = 'cshApiVersionCache';
+    var CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+    function pickHighest(list) {
+        if (!Array.isArray(list) || list.length === 0) return null;
+        var best = null;
+        for (var i = 0; i < list.length; i++) {
+            var v = parseFloat(list[i] && list[i].version);
+            if (!isNaN(v) && (best === null || v > best)) best = v;
+        }
+        return best !== null ? best.toFixed(1) : null;
+    }
+
+    function readCache(host) {
+        return new Promise(function (resolve) {
+            if (!chrome.storage || !chrome.storage.local) return resolve(null);
+            chrome.storage.local.get([CACHE_KEY], function (items) {
+                var cache = items[CACHE_KEY] || {};
+                var entry = cache[host];
+                if (entry && entry.version && entry.at && (Date.now() - entry.at) < CACHE_TTL_MS) {
+                    resolve(entry.version);
+                } else {
+                    resolve(null);
+                }
+            });
+        });
+    }
+
+    function writeCache(host, version) {
+        if (!chrome.storage || !chrome.storage.local) return;
+        chrome.storage.local.get([CACHE_KEY], function (items) {
+            var cache = items[CACHE_KEY] || {};
+            cache[host] = { version: version, at: Date.now() };
+            chrome.storage.local.set({ [CACHE_KEY]: cache });
+        });
+    }
+
+    function probe(host) {
+        return fetch(host + '/services/data/', { credentials: 'include' })
+            .then(function (r) { return r.ok ? r.json() : null; })
+            .then(pickHighest)
+            .catch(function () { return null; });
+    }
+
+    function readSyncPref() {
+        return new Promise(function (resolve) {
+            if (!chrome.storage || !chrome.storage.sync) return resolve(null);
+            chrome.storage.sync.get(['salesforceApiVersion'], function (items) {
+                resolve(items && items.salesforceApiVersion ? items.salesforceApiVersion : null);
+            });
+        });
+    }
+
+    async function resolveApiVersion() {
+        var host = serverUrl;
+        var cached = await readCache(host);
+        if (cached) return cached;
+
+        var probed = await probe(host);
+        if (probed) {
+            writeCache(host, probed);
+            return probed;
+        }
+
+        var pref = await readSyncPref();
+        return pref || FALLBACK;
+    }
+
+    window.cshApiVersion = {
+        fallback: FALLBACK,
+        resolve: resolveApiVersion
+    };
+
+    // Kick off discovery on script load and publish the result so the service
+    // worker / offscreen document can pick it up via chrome.storage.local.
+    // The user's explicit preference in chrome.storage.sync always wins — we
+    // only populate the local cache as a fallback.
+    resolveApiVersion().then(function (version) {
+        if (!version) return;
+        if (!chrome.storage || !chrome.storage.local) return;
+        chrome.storage.local.set({ cshResolvedApiVersion: version });
+    }).catch(function () { /* ignore — background falls back to 60.0 */ });
+})();

--- a/deployhelper.js
+++ b/deployhelper.js
@@ -131,7 +131,7 @@ function oauthLogin() {
 	  console.log(response);
 	 if (response.error) {
 		 console.log("Problem logging in: " + response.error);
-		 alert('Problem logging in ' + response.error);
+		 window.cshToast && window.cshToast.show('Problem logging in: ' + response.error, { type: 'error' });
 		 //do nothing else
 	 } else {
               $("#loginSection").hide();

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "manifest_version": 3,
   "name": "Salesforce Change Set Helper",
   "description": "Enhances the Salesforce change set. Adds last changed date and allows sorting, searching, validation and comparison with other orgs.",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "options_page": "options.html",
   "action": {
     "default_icon": "braincloudsmall.png",

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "manifest_version": 3,
   "name": "Salesforce Change Set Helper",
   "description": "Enhances the Salesforce change set. Adds last changed date and allows sorting, searching, validation and comparison with other orgs.",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "options_page": "options.html",
   "action": {
     "default_icon": "braincloudsmall.png",

--- a/metadatahelper.js
+++ b/metadatahelper.js
@@ -28,8 +28,11 @@ function downloadPackage() {
             },
             function (response) {
                 if (response.err) {
-                    alert('There was a problem downloading the package.');
-                    console.err;
+                    window.cshToast && window.cshToast.show(
+                        'There was a problem downloading the package.\n\n' + (response.err.message || response.err),
+                        { type: 'error' }
+                    );
+                    console.error(response.err);
                     unSetDownloading();
                 } else {
                     var zip = new JSZip();

--- a/offscreen.js
+++ b/offscreen.js
@@ -27,26 +27,44 @@ function initializeOffscreen() {
         console.log('JSforce library loaded successfully, version:', jsforce.VERSION || 'unknown');
     }
 
-    // Initialize chrome.storage API calls after Chrome APIs are ready
+    // Initialize chrome.storage API calls after Chrome APIs are ready.
+    // Same priority ladder as background.js: sync user pref > local auto > 60.0.
+    var offscreenIsUserPref = false;
     try {
         if (chrome && chrome.storage && chrome.storage.sync) {
-            // Get initial API version from storage
-            chrome.storage.sync.get(['salesforceApiVersion'], function(items) {
+            chrome.storage.sync.get(['salesforceApiVersion'], function (items) {
                 if (chrome.runtime.lastError) {
-                    console.log('Could not read storage:', chrome.runtime.lastError.message);
+                    console.log('Could not read sync storage:', chrome.runtime.lastError.message);
                     return;
                 }
-                if (items.salesforceApiVersion) {
-                    CSH_APIVERSION = versionPattern.test(items.salesforceApiVersion) ? items.salesforceApiVersion : '60.0';
-                    console.log('Offscreen - API Version:', CSH_APIVERSION);
+                if (items && items.salesforceApiVersion && versionPattern.test(items.salesforceApiVersion)) {
+                    CSH_APIVERSION = items.salesforceApiVersion;
+                    offscreenIsUserPref = true;
+                    console.log('Offscreen - API Version:', CSH_APIVERSION, '(user pref)');
+                    return;
                 }
+                chrome.storage.local.get(['cshResolvedApiVersion'], function (local) {
+                    if (local && local.cshResolvedApiVersion && versionPattern.test(local.cshResolvedApiVersion)) {
+                        CSH_APIVERSION = local.cshResolvedApiVersion;
+                        console.log('Offscreen - API Version:', CSH_APIVERSION, '(auto)');
+                    }
+                });
             });
 
-            // Listen for API version changes
             chrome.storage.onChanged.addListener(function (changes, areaName) {
-                if (changes.salesforceApiVersion) {
-                    CSH_APIVERSION = versionPattern.test(changes.salesforceApiVersion.newValue) ? changes.salesforceApiVersion.newValue : '60.0';
-                    console.log('Offscreen - API Version changed:', CSH_APIVERSION);
+                if (areaName === 'sync' && changes.salesforceApiVersion) {
+                    if (versionPattern.test(changes.salesforceApiVersion.newValue)) {
+                        CSH_APIVERSION = changes.salesforceApiVersion.newValue;
+                        offscreenIsUserPref = true;
+                        console.log('Offscreen - API Version changed:', CSH_APIVERSION, '(user pref)');
+                    }
+                    return;
+                }
+                if (areaName === 'local' && changes.cshResolvedApiVersion && !offscreenIsUserPref) {
+                    if (versionPattern.test(changes.cshResolvedApiVersion.newValue)) {
+                        CSH_APIVERSION = changes.cshResolvedApiVersion.newValue;
+                        console.log('Offscreen - API Version changed:', CSH_APIVERSION, '(auto)');
+                    }
                 }
             });
 


### PR DESCRIPTION
## Summary

First of several planned phases toward a Copado-Essentials-like deployment experience. Focus: **stop breaking** on current pages and give the rest of the roadmap a clean baseline.

Six fixes, one squashed commit:

1. **`jQuery.noConflict(true)` in `common.js`** — hardens against clobbering any `$` / `jQuery` a page or another extension may bind. Defensive, not the full cure for the `OverlayDialog` Spring '26 regression — see caveats below.
2. **Dynamic header-scan in `setupTable()`** — captures the original `<th>/<td>` counts for header and rows before we mutate them. Every downstream column-index calculation (`applyMetadataToRows`, `createDataTable`, `tableInitComplete`) now keys off these snapshots instead of the old `typeColumn.length > 0 ? 2 : 1` guess. Fixes alignment for entity types that render an extra base column (Parent Object): CustomField, WorkflowFieldUpdate, WorkflowTask, WorkflowAlert, RecordType, ListView, CompactLayout.
3. **Per-row cell equalization in `addColumnsToRows`** — two-pass pad: find widest existing row, pad every row up to `widest + (dynamic + 4 compare)`. Prevents ragged rows when Salesforce emits mixed row shapes under a single `tr.dataRow` selector.
4. **Union-of-properties in `determineMetadataColumns`** — now accepts an array and unions usable properties across the first 25 records. Managed-package records with extra fields, or older components missing `createdByName`, no longer silently drop columns.
5. **Toast replacing `alert()`** — new `window.cshToast.show()` in `common.js` with SLDS-ish styling and auto-dismiss. All 6 `alert()` calls swapped (4 in changeset.js, 1 in deployhelper.js, 1 in metadatahelper.js).
6. **Dynamic Salesforce API-version discovery** — `common.js` probes `/services/data/` on load and caches the highest supported version in `chrome.storage.local` per-host for 24h. `background.js` and `offscreen.js` now follow a priority ladder: **sync user pref → local auto-detect → 60.0 fallback**. Options-page overrides stay authoritative.

## Why not more?

This is Phase 1 of the roadmap discussed. Phases 2-4 (universal metadata coverage via `describeMetadata()`, Tooling-API `SourceMember` for code, Copado-style diff UI, dependency pre-flight, command palette, auto-rollback snapshot) intentionally not in scope here.

## Caveats / known unknowns

- **`OverlayDialog is not defined`** — Phase 1 adds `noConflict` for hardening, but this error comes from Salesforce's own `Setup.js` in the Classic iframe on Spring '26. Content scripts live in the isolated world so they don't directly clobber the page's `$`; the error may be a Salesforce platform regression or a timing issue induced by `all_frames: true`. Needs live verification in the user's org after this PR.
- `node --check` passes on all 6 modified files. No automated tests exist in this repo — manual verification in a real SF sandbox is required.

## Test plan

- [ ] Load unpacked into Chrome dev mode from this branch.
- [ ] Navigate to an Add-Components page on **each** of these types and verify columns line up, no console errors, metadata populates:
  - [ ] ApexClass (Name only — baseline)
  - [ ] CustomField (Name + Parent Object — previously mis-aligned)
  - [ ] WorkflowFieldUpdate (Name + Parent Object)
  - [ ] RecordType (Name + Parent Object)
  - [ ] Report / Dashboard (folder-based)
  - [ ] LightningComponentBundle (modern packaging)
- [ ] Trigger each error path and confirm a toast appears instead of an `alert()`:
  - [ ] Deny OAuth on "Compare with org" (deployhelper.js)
  - [ ] Simulate a 401 during metadata list (changeset.js)
  - [ ] Corrupt a ZIP download (metadatahelper.js — may need temporary tweak)
- [ ] Verify API version:
  - [ ] Fresh install (no sync pref): open DevTools, check `chrome.storage.local` for `cshResolvedApiVersion`.
  - [ ] Set options page to 58.0: background console should log `(user pref)`, not `(auto)`.
- [ ] Spot-check that large-dataset pagination (>1000 rows) still works — this PR did not touch the pagination path, but column math feeds into it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)