### PR TITLE
Phase 2: describeMetadata-driven type coverage

### DIFF
--- a/background.js
+++ b/background.js
@@ -297,6 +297,19 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
         return true;
     }
 
+    if (request.proxyFunction == "describeLocalMetadata") {
+        sendToOffscreen({
+            action: 'describeMetadata',
+            connType: 'local'
+        }).then(response => {
+            sendResponse({err: response.error || null, results: response.results});
+        }).catch(err => {
+            console.error('Error in describeLocalMetadata:', err);
+            sendResponse({err: err.message, results: null});
+        });
+        return true;
+    }
+
     if (request.proxyFunction == "downloadLocalMetadata") {
         sendToOffscreen({
             action: 'downloadMetadata',

--- a/changeset.js
+++ b/changeset.js
@@ -6,6 +6,7 @@ var totalComponentCount = 0; // Track total rows loaded for pagination decisions
 var isLoadingMorePages = false; // Flag to indicate we're still loading pages in background
 var cachedMetadataResults = []; // Store metadata results to reuse during pagination
 var dynamicColumns = null; // Store dynamic column configuration based on metadata properties
+var resolvedMetadataType = null; // Metadata API type name resolved via override map or describeMetadata cache
 
 // Compare functionality column indices (set dynamically after table setup)
 var compareColumnIndices = {
@@ -950,7 +951,7 @@ function getMetaData(processResultsFunction) {
                     n++;
                     folderName = results[i].fullName;
                     var folderQuery = {};
-                    folderQuery.type = entityTypeMap[selectedEntityType];
+                    folderQuery.type = resolvedMetadataType;
                     folderQuery.folder = folderName;
                     folderQueries.push(folderQuery);
                     if (n == 3) {
@@ -983,7 +984,7 @@ function getMetaData(processResultsFunction) {
         numCallsInProgress++;
         chrome.runtime.sendMessage({
                 'proxyFunction': "listLocalMetaData",
-                'proxydata': [{type: entityTypeMap[selectedEntityType]}]
+                'proxydata': [{type: resolvedMetadataType}]
             },
             processResultsFunction
         );
@@ -1015,7 +1016,7 @@ function oauthLogin(env) {
         $("#loggedInUsername").html(response.username);
         $("#logout").show();
 
-        listMetaDataProxy([{type: entityTypeMap[selectedEntityType]}],
+        listMetaDataProxy([{type: resolvedMetadataType}],
             function (results) {
                 if (results.error) {
                     console.log("Problem logging in: " + results.error);
@@ -1038,7 +1039,7 @@ function getContents() {
     //(itemToGet);
     chrome.runtime.sendMessage({
             'proxyFunction': "compareContents",
-            'entityType': entityTypeMap[selectedEntityType],
+            'entityType': resolvedMetadataType,
             'itemName': itemToGet
         },
         function (response) {
@@ -1080,8 +1081,38 @@ var nextPageLsr = 1000;
 var shouldContinuePagination = false;
 var ENABLE_PAGINATION_THRESHOLD = 1500; // Enable DataTables paging above this threshold
 
-// Show loading overlay and fetch metadata FIRST before showing any rows
-if (selectedEntityType in entityTypeMap) {
+// Resolve the UI entity name (e.g. "ApexClass", "CustomEntityDefinition",
+// "LightningMessageChannel") to a Metadata API type name:
+//   1. hardcoded entityTypeMap override (for UI names that differ from API names)
+//   2. describeMetadata identity match from the per-host cache
+//   3. null → type is not yet supported; we fall back to a plain DataTable
+// Describe-based resolution eliminates most of the need to hand-maintain the
+// override map as Salesforce adds new component types each release.
+window.cshMetadata.getDescribe().then(function (describeCache) {
+    resolvedMetadataType = window.cshMetadata.resolveEntityType(
+        selectedEntityType, describeCache, entityTypeMap
+    );
+    console.log('Entity type resolution:', selectedEntityType, '->', resolvedMetadataType,
+                describeCache ? '(describe cache warm)' : '(describe cache cold)');
+
+    if (resolvedMetadataType == null) {
+        // Coverage gap — toast the user so they know why the table isn't enhanced.
+        window.cshToast && window.cshToast.show(
+            'Metadata enhancement is not available for "' + selectedEntityType + '".\n\n' +
+            'The table will still load. To enable last-modified columns for this type, ' +
+            'visit any supported component type first to refresh the type cache, ' +
+            'then return to this page.',
+            { type: 'info', duration: 10000 }
+        );
+        totalComponentCount = listTableLength;
+        startMetadataLoading();
+        return;
+    }
+
+    runEnhancedFlow();
+});
+
+function runEnhancedFlow() {
     // Show loading spinner
     var loadingHtml = `
         <style>
@@ -1141,6 +1172,15 @@ if (selectedEntityType in entityTypeMap) {
 
         console.log('Fetching metadata before loading rows for type:', selectedEntityType);
 
+        // Warm the describeMetadata cache in the background — doesn't block
+        // list fetching. Fresh cache feeds resolveEntityType() on the next visit,
+        // so newly added Salesforce types become supported without a release.
+        if (window.cshMetadata && window.cshMetadata.warmDescribeCache) {
+            window.cshMetadata.warmDescribeCache().catch(function (e) {
+                console.warn('warmDescribeCache failed:', e && e.message);
+            });
+        }
+
         try {
             // Custom callback that waits for all metadata calls to complete
             getMetaData(function(metadataResponse) {
@@ -1179,11 +1219,9 @@ if (selectedEntityType in entityTypeMap) {
             $("#bodyCell").removeClass("changesetloading");
         }
     });
-} else {
-    // Non-mapped entity types - proceed without metadata
-    totalComponentCount = listTableLength;
-    startMetadataLoading();
 }
+// End of runEnhancedFlow — the coverage-gap path is handled inside the
+// resolveEntityType .then() above.
 
 // Function to start pagination after metadata is loaded
 function startPaginationWithMetadata() {
@@ -1315,7 +1353,7 @@ function startPaginationWithMetadata() {
             var nextTable = parsedResponse.find("table.list tr.dataRow");
 
             // Add columns to new rows
-            if (selectedEntityType in entityTypeMap) {
+            if (resolvedMetadataType != null) {
                 addColumnsToRows(nextTable);
             }
 
@@ -1436,7 +1474,7 @@ function initializeTableWithMetadata() {
 
 // Function to start metadata loading after pagination is complete (or skipped)
 function startMetadataLoading() {
-    if (selectedEntityType in entityTypeMap) {
+    if (resolvedMetadataType != null) {
         // Don't call setupTable yet - wait until first metadata batch returns
         // so we can determine dynamic columns from the metadata properties
         $("#editPage").addClass("lowOpacity");

--- a/common.js
+++ b/common.js
@@ -221,7 +221,122 @@ var serverUrl = window.location.protocol + '//' + window.location.host;
     // only populate the local cache as a fallback.
     resolveApiVersion().then(function (version) {
         if (!version) return;
+        window.cshApiVersion.resolved = version;
         if (!chrome.storage || !chrome.storage.local) return;
         chrome.storage.local.set({ cshResolvedApiVersion: version });
     }).catch(function () { /* ignore — background falls back to 60.0 */ });
+})();
+
+// 5) describeMetadata cache + dynamic entity-type resolver.
+//    The Salesforce UI enumeration in the Component Type picker drifts between
+//    releases — every new release adds types we'd otherwise have to hard-code.
+//    Caching the result of `conn.metadata.describe(apiVersion)` lets us answer
+//    "is this a valid metadata type" from a live source of truth. We still
+//    apply a small override map for types whose UI name differs from the API
+//    name (TabSet → CustomApplication, ValidationFormula → ValidationRule …).
+(function () {
+    var CACHE_KEY = 'cshMetadataDescribe';
+    var TTL_MS = 24 * 60 * 60 * 1000;
+
+    function cacheKey(host, apiVersion) {
+        return host + '|' + (apiVersion || 'latest');
+    }
+
+    function readCache() {
+        return new Promise(function (resolve) {
+            if (!chrome.storage || !chrome.storage.local) return resolve(null);
+            chrome.storage.local.get([CACHE_KEY], function (items) {
+                var cache = items[CACHE_KEY] || {};
+                var apiVersion = (window.cshApiVersion && window.cshApiVersion.resolved) || 'latest';
+                var entry = cache[cacheKey(serverUrl, apiVersion)];
+                if (entry && entry.at && (Date.now() - entry.at) < TTL_MS) {
+                    resolve(entry.data);
+                } else {
+                    resolve(null);
+                }
+            });
+        });
+    }
+
+    function writeCache(data) {
+        if (!chrome.storage || !chrome.storage.local) return;
+        var apiVersion = (window.cshApiVersion && window.cshApiVersion.resolved) || 'latest';
+        var key = cacheKey(serverUrl, apiVersion);
+        chrome.storage.local.get([CACHE_KEY], function (items) {
+            var cache = items[CACHE_KEY] || {};
+            cache[key] = { at: Date.now(), data: data };
+            chrome.storage.local.set({ [CACHE_KEY]: cache });
+        });
+    }
+
+    function fetchDescribe() {
+        return new Promise(function (resolve) {
+            if (!chrome || !chrome.runtime || !chrome.runtime.sendMessage) return resolve(null);
+            chrome.runtime.sendMessage({ proxyFunction: 'describeLocalMetadata' }, function (response) {
+                if (chrome.runtime.lastError) {
+                    console.warn('cshMetadata.fetchDescribe: runtime error', chrome.runtime.lastError.message);
+                    return resolve(null);
+                }
+                if (!response || response.err || !response.results) {
+                    console.warn('cshMetadata.fetchDescribe: no results', response && response.err);
+                    return resolve(null);
+                }
+                resolve(response.results);
+            });
+        });
+    }
+
+    // Returns the cached describeMetadata result, or null if the cache is cold
+    // or expired. Does NOT hit the network — call warmDescribeCache() after a
+    // successful JSforce connect to refresh the cache without blocking UI.
+    async function getDescribe() {
+        return await readCache();
+    }
+
+    // Fetches describeMetadata via the offscreen JSforce connection and writes
+    // it to cache. Must be called only AFTER connectToLocal has succeeded,
+    // otherwise the offscreen document has no connection to use.
+    async function warmDescribeCache() {
+        var cached = await readCache();
+        if (cached) return cached;
+        var fresh = await fetchDescribe();
+        if (fresh) writeCache(fresh);
+        return fresh;
+    }
+
+    // Resolve a Salesforce UI entity name (what appears in the #entityType
+    // hidden field) to a Metadata API type name.
+    //   1. override map: hardcoded translations for UI names that differ from
+    //      API names (stable, small).
+    //   2. describe identity match: if describe contains a metadataObject
+    //      whose xmlName equals the UI name, use that directly. Catches every
+    //      new type Salesforce adds without code changes.
+    //   Returns null when neither path produces a mapping.
+    function resolveEntityType(uiName, describeData, overrideMap) {
+        if (!uiName) return null;
+        if (overrideMap && Object.prototype.hasOwnProperty.call(overrideMap, uiName)) {
+            return overrideMap[uiName];
+        }
+        if (describeData && Array.isArray(describeData.metadataObjects)) {
+            for (var i = 0; i < describeData.metadataObjects.length; i++) {
+                var mo = describeData.metadataObjects[i];
+                if (mo && mo.xmlName === uiName) return uiName;
+                // Fold "children" (e.g. CustomField lives under CustomObject's childXmlNames)
+                if (mo && Array.isArray(mo.childXmlNames)) {
+                    for (var j = 0; j < mo.childXmlNames.length; j++) {
+                        if (mo.childXmlNames[j] === uiName) return uiName;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    window.cshMetadata = {
+        getDescribe: getDescribe,
+        warmDescribeCache: warmDescribeCache,
+        resolveEntityType: resolveEntityType,
+        CACHE_KEY: CACHE_KEY,
+        TTL_MS: TTL_MS
+    };
 })();

--- a/offscreen.js
+++ b/offscreen.js
@@ -116,6 +116,12 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
                 .catch(err => sendResponse({error: err.message}));
             return true;
 
+        case 'describeMetadata':
+            describeMetadata(request.connType)
+                .then(results => sendResponse({results: results}))
+                .catch(err => sendResponse({error: err.message}));
+            return true;
+
         case 'downloadMetadata':
             downloadMetadata(request.connType, request.changename)
                 .then(result => sendResponse({result: result}))
@@ -217,6 +223,24 @@ async function listMetadata(connType, types) {
                 reject(err);
             } else {
                 resolve(results);
+            }
+        });
+    });
+}
+
+async function describeMetadata(connType) {
+    const conn = connType === 'deploy' ? connDeploy.conn : connLocal.conn;
+
+    if (!conn) {
+        throw new Error('Not connected');
+    }
+
+    return new Promise((resolve, reject) => {
+        conn.metadata.describe(CSH_APIVERSION, function(err, result) {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(result);
             }
         });
     });


### PR DESCRIPTION
## Summary

Builds on PR #9. Makes the extension pick up every Salesforce metadata type that \`describeMetadata()\` reports, without hand-maintaining \`entityTypeMap\`.

Three changes shipping together:

1. **describeMetadata plumbing** — new handler in \`offscreen.js\`, new proxy (\`describeLocalMetadata\`) in \`background.js\`. Uses the existing JSforce connection; no extra permissions.
2. **\`window.cshMetadata\` helpers in \`common.js\`** — per-host + per-api-version describe cache in \`chrome.storage.local\` (24 h TTL), \`warmDescribeCache()\` post-connect, and a \`resolveEntityType(uiName, describe, overrideMap)\` resolver that tries the hardcoded override map first, then an identity match against \`metadataObjects.xmlName\` and \`childXmlNames\`. Returns null when unsupported.
3. **\`changeset.js\` integration** — new \`resolvedMetadataType\` module var replaces every \`entityTypeMap[selectedEntityType]\` call site and every \`selectedEntityType in entityTypeMap\` gate. Resolution is the first async step in the main block; the existing enhanced-flow code is now gated on the resolver's result. Coverage gap → SLDS info toast explaining that the table will still load and how to self-warm the cache.

## Why this matters

- Types Salesforce adds each release (e.g. modern \`Flow\` replacing \`FlowDefinition\`, \`LightningMessageChannel\`, \`ExperienceBundle\`, \`CustomMetadata\`, OmniChannel\*, \`CustomNotificationType\`, and a long tail of Service Cloud types) start working **without a release** once any supported page has warmed the cache.
- The hardcoded \`entityTypeMap\` can stay small and focused on UI-name-to-API-name translations that Salesforce actually renames (TabSet → CustomApplication, CustomEntityDefinition → CustomObject, ValidationFormula → ValidationRule, ProcessDefinition → ApprovalProcess, ActionEmail → WorkflowAlert, etc.).

## Stacked on Phase 1

This PR targets \`phase-1-stability\` (PR #9). GitHub will allow merging after #9 lands; if #9 is rebased I'll rebase this one too.

## Test plan

- [ ] Merge #9 first, then rebase this onto \`master\`, or review on the stacked branch directly.
- [ ] First load of a known-supported type (e.g. ApexClass):
  - [ ] Console shows \`Entity type resolution: ApexClass -> ApexClass (describe cache cold)\` first, then a \`warmDescribeCache\` log.
  - [ ] \`chrome.storage.local\` now contains \`cshMetadataDescribe\` keyed by \`<host>|<apiVersion>\`.
- [ ] Reload: should log \`(describe cache warm)\`.
- [ ] Visit an unmapped but newly-supported type (\`Flow\`, \`LightningMessageChannel\`, \`CustomMetadata\`):
  - [ ] Without a warm cache: info toast shown, basic table renders.
  - [ ] With a warm cache: identity match succeeds, metadata columns populate normally.
- [ ] Visit a truly bogus type (shouldn't happen in practice): info toast + basic table, no hang.
- [ ] Compare-with-org on an unmapped-but-resolved type still works (uses \`resolvedMetadataType\`).
- [ ] Cache TTL: flip your system clock forward 24h + 1 min, reload — fetch + re-cache should fire.
- [ ] Pagination past 1000 rows still enhances new rows (\`resolvedMetadataType != null\` gate).

## Known follow-ups (deferred to later phases)

- Tooling API \`SourceMember\` for faster code-type metadata (Phase 2.3)
- Cookies-API session fallback so HttpOnly doesn't need to be disabled (Phase 2.4)
- Copado-style diff UI, dependency pre-flight, command palette, auto-rollback snapshot (Phases 3-4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)