### PR TITLE
Phase 2.4: cookies-API session fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,9 @@ From the Outbound Change Set Detail page:
 
 ### Salesforce Configuration
 
-**Important**: For the extension to access session IDs, you must:
+**No longer required as of v3.0.3.** The extension reads the Salesforce session via the Chrome `cookies` permission, which works whether or not **Require HttpOnly attribute** is enabled in Session Settings. If you previously unchecked it for this extension and don't need it off for any other reason, you can safely re-enable it.
+
+If your org blocks the extension from the `cookies` permission, the old fallback still works:
 
 1. Go to **Setup** → **Session Settings**
 2. Find **"Require HttpOnly attribute"**

--- a/background.js
+++ b/background.js
@@ -243,6 +243,37 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
         return true;
     }
 
+    if (request.type == "getSessionCookie") {
+        // HttpOnly-cookie fallback: content scripts can't read the sid cookie
+        // directly when the org has "Require HttpOnly attribute" enabled, but
+        // the cookies API can. We search the most common Salesforce cookie
+        // stores and return the first hit. Falls back silently to null.
+        (async function () {
+            try {
+                var url = request.url || (sender && sender.tab && sender.tab.url);
+                if (!url) {
+                    sendResponse({ sid: null, reason: 'no-url' });
+                    return;
+                }
+                var storeId = sender && sender.tab && sender.tab.cookieStoreId;
+                var getOpts = storeId
+                    ? { url: url, name: 'sid', storeId: storeId }
+                    : { url: url, name: 'sid' };
+                chrome.cookies.get(getOpts, function (cookie) {
+                    if (chrome.runtime.lastError || !cookie || !cookie.value) {
+                        sendResponse({ sid: null, reason: 'not-found' });
+                        return;
+                    }
+                    sendResponse({ sid: cookie.value });
+                });
+            } catch (err) {
+                console.error('getSessionCookie failed:', err);
+                sendResponse({ sid: null, reason: 'exception', error: err.message });
+            }
+        })();
+        return true;
+    }
+
     if (request.oauth == "connectToDeploy") {
         connectToDeploy(sendResponse, request.environment);
         return true;

--- a/changeset.js
+++ b/changeset.js
@@ -1137,12 +1137,26 @@ function runEnhancedFlow() {
     $("#editPage").addClass("lowOpacity");
     $("#bodyCell").addClass("changesetloading");
 
-    // Fetch metadata FIRST
-    chrome.runtime.sendMessage({
-        "oauth": "connectToLocal",
-        "sessionId": sessionId,
-        "serverUrl": serverUrl
-    }, function (response) {
+    // Wait for the session id. On HttpOnly-on orgs the fast sync read is
+    // empty, but cshSession.ready resolves via the cookies API fallback.
+    window.cshSession.ready.then(function (sid) {
+        if (!sid) {
+            $('#csh-loading-overlay').remove();
+            window.cshToast && window.cshToast.show(
+                'Could not read your Salesforce session cookie. Ensure the Change Set Helper ' +
+                'has the "cookies" permission enabled, or uncheck Session Settings → Require HttpOnly.',
+                { type: 'error' }
+            );
+            $("#editPage").removeClass("lowOpacity");
+            $("#bodyCell").removeClass("changesetloading");
+            return;
+        }
+        // Fetch metadata FIRST
+        chrome.runtime.sendMessage({
+            "oauth": "connectToLocal",
+            "sessionId": sid,
+            "serverUrl": serverUrl
+        }, function (response) {
         // Check for Chrome runtime errors only
         if (chrome.runtime.lastError) {
             console.error('OAuth connection failed:', chrome.runtime.lastError);
@@ -1218,7 +1232,8 @@ function runEnhancedFlow() {
             $("#editPage").removeClass("lowOpacity");
             $("#bodyCell").removeClass("changesetloading");
         }
-    });
+        }); // end chrome.runtime.sendMessage connectToLocal
+    }); // end window.cshSession.ready.then
 }
 // End of runEnhancedFlow — the coverage-gap path is handled inside the
 // resolveEntityType .then() above.
@@ -1480,13 +1495,21 @@ function startMetadataLoading() {
         $("#editPage").addClass("lowOpacity");
         $("#bodyCell").addClass("changesetloading");
 
-        chrome.runtime.sendMessage({
-            "oauth": "connectToLocal",
-            "sessionId": sessionId,
-            "serverUrl": serverUrl
-        }, function (response) {
-            console.log('Fetching metadata to determine table columns for type:', selectedEntityType);
-            getMetaData(processListResults);
+        window.cshSession.ready.then(function (sid) {
+            if (!sid) {
+                console.warn('startMetadataLoading: no session id resolved');
+                $("#editPage").removeClass("lowOpacity");
+                $("#bodyCell").removeClass("changesetloading");
+                return;
+            }
+            chrome.runtime.sendMessage({
+                "oauth": "connectToLocal",
+                "sessionId": sid,
+                "serverUrl": serverUrl
+            }, function (response) {
+                console.log('Fetching metadata to determine table columns for type:', selectedEntityType);
+                getMetaData(processListResults);
+            });
         });
     } else {
         // Non-mapped entity types - setup basic table
@@ -1531,8 +1554,29 @@ $(document).ready(function () {
 
     $('input[name="cancel"]').parent().on('click','#compareorg' , oauthLogin);
 
-    if (!sessionId) {
-        $('.bDescription').append('<span style="background-color:yellow"><strong><br/> <br/>Sorry, currently for the Change Set Helper to work, please UNSET the Require HTTPOnly Attribute checkbox in Security -> Session Settings. Then logout and back in again.  </strong></span>')
+    // Only warn about HttpOnly after the cookies-API fallback has had a chance
+    // to resolve — on HttpOnly-on orgs the fast-path read fails but the
+    // background can still retrieve the session via chrome.cookies.get.
+    if (window.cshSession && window.cshSession.ready) {
+        window.cshSession.ready.then(function (sid) {
+            if (!sid) {
+                $('.bDescription').append(
+                    '<span style="background-color:yellow"><strong><br/> <br/>' +
+                    'The Change Set Helper could not read the Salesforce session cookie. ' +
+                    'Either grant the extension the "cookies" permission (usually automatic) ' +
+                    'or uncheck Setup → Session Settings → Require HttpOnly attribute.' +
+                    '</strong></span>'
+                );
+            }
+        });
+    } else if (!sessionId) {
+        $('.bDescription').append(
+            '<span style="background-color:yellow"><strong><br/> <br/>' +
+            'Sorry, currently for the Change Set Helper to work, please UNSET the Require ' +
+            'HTTPOnly Attribute checkbox in Security -&gt; Session Settings. Then logout ' +
+            'and back in again.' +
+            '</strong></span>'
+        );
     }
 });
 

--- a/common.js
+++ b/common.js
@@ -23,12 +23,49 @@ if (typeof window !== 'undefined' && window.jQuery && typeof window.jQuery.noCon
     }
 }
 
-// 2) Session context — unchanged from the original extension.
+// 2) Session context.
+//    Fast path: read sid from document.cookie (works when the org has
+//    HttpOnly off). Fallback path: ask the service worker to read via
+//    chrome.cookies.get, which sees HttpOnly cookies. Callers that run
+//    synchronously (the legacy `if (sessionId) { ... }` gates) use the
+//    fast-path value; anything that kicks off network work should await
+//    window.cshSession.ready to catch the async-resolved value.
 var sessionId = (function () {
     var m = document.cookie.match('sid=([^;]*)');
     return m ? m[1] : null;
 })();
 var serverUrl = window.location.protocol + '//' + window.location.host;
+
+window.cshSession = (function () {
+    function askBackgroundForCookie() {
+        return new Promise(function (resolve) {
+            if (!chrome || !chrome.runtime || !chrome.runtime.sendMessage) return resolve(null);
+            chrome.runtime.sendMessage(
+                { type: 'getSessionCookie', url: window.location.href },
+                function (response) {
+                    if (chrome.runtime.lastError) {
+                        console.warn('cshSession: background fallback failed:', chrome.runtime.lastError.message);
+                        return resolve(null);
+                    }
+                    if (response && response.sid) {
+                        sessionId = response.sid; // update module-scoped var so legacy callers see it
+                        return resolve(response.sid);
+                    }
+                    resolve(null);
+                }
+            );
+        });
+    }
+
+    var readyPromise = sessionId ? Promise.resolve(sessionId) : askBackgroundForCookie();
+
+    return {
+        ready: readyPromise,
+        // Returns the current session id synchronously; may be null until
+        // ready resolves on HttpOnly-on orgs.
+        current: function () { return sessionId; }
+    };
+})();
 
 // 3) Lightweight SLDS-styled toast, used in place of alert().
 //    window.cshToast.show(message, { type: 'error' | 'warning' | 'success' | 'info', duration })

--- a/deployhelper.js
+++ b/deployhelper.js
@@ -1,5 +1,4 @@
-if (sessionId) {
-
+function cshRenderDeployHelper() {
 	$('.bDescription').append(`
     <div class='apexp'>
 	<div class="bPageBlock brandSecondaryBrd apexDefaultPageBlock secondaryPalette">
@@ -82,9 +81,10 @@ function testDeploy() {
 	$('#cancelDeploy').hide();
 	$('#json-renderer').jsonViewer();
 
+	var sid = (window.cshSession && window.cshSession.current && window.cshSession.current()) || sessionId;
 	var port = chrome.runtime.connect({name: "deployHandler"});
 
-	port.postMessage({'proxyFunction': "deploy", 'opts': opts, "changename": changename, "sessionId":sessionId, "serverUrl":serverUrl});
+	port.postMessage({'proxyFunction': "deploy", 'opts': opts, "changename": changename, "sessionId":sid, "serverUrl":serverUrl});
 	port.onMessage.addListener(function(msg) {
 		console.log('Listining!');
 		console.log(msg);
@@ -238,17 +238,26 @@ function quickDeploy() {
 }
 
 
-if (sessionId) {
+(function () {
+	function wireDeployHelper() {
+		cshRenderDeployHelper();
+		$("#deployLogin").click(deployLogin);
+		$("#deployTest").click(testDeploy);
+		$("#logoutLink").click(deployLogout);
+		$("#cancelDeploy").click(cancelDeploy);
+		$("#quickDeploy").click(quickDeploy);
 
-	$("#deployLogin").click(deployLogin);
-	$("#deployTest").click(testDeploy);
-	$("#logoutLink").click(deployLogout);
-	$("#cancelDeploy").click(cancelDeploy);
-	$("#quickDeploy").click(quickDeploy);
+		$("#validateSection").hide();
+		$("#quickDeploy").hide();
+		$("#cancelDeploy").hide();
+	}
 
-
-	$("#validateSection").hide();
-	$("#quickDeploy").hide();
-	$("#cancelDeploy").hide();
-}
+	if (window.cshSession && window.cshSession.ready) {
+		window.cshSession.ready.then(function (sid) {
+			if (sid) wireDeployHelper();
+		});
+	} else if (sessionId) {
+		wireDeployHelper();
+	}
+})();
 

--- a/manifest.json
+++ b/manifest.json
@@ -98,14 +98,18 @@
   "permissions": [
     "identity",
     "storage",
-    "offscreen"
+    "offscreen",
+    "cookies"
   ],
   "host_permissions": [
     "https://*.com/p/mfpkg/AddToPackageFromChangeMgmtUi*",
     "https://*.com/p/mfpkg/AddToPackageUi*",
     "https://*.com/*tab=PackageComponents*",
     "https://*.com/changemgmt/outboundChangeSetDetailPage.apexp*",
-    "https://*.salesforce.com/services/*"
+    "https://*.salesforce.com/*",
+    "https://*.force.com/*",
+    "https://*.cloudforce.com/*",
+    "https://*.salesforce-setup.com/*"
   ],
   "background": {
     "service_worker": "background.js"

--- a/metadatahelper.js
+++ b/metadatahelper.js
@@ -17,9 +17,18 @@ var getUrlParameter = function getUrlParameter(sParam) {
 function downloadPackage() {
     setDownloading();
     console.log('Downloading package: ' + changename + ' Ensure that this package is uniquely named and contains no weird characters.')
+    window.cshSession.ready.then(function (sid) {
+    if (!sid) {
+        unSetDownloading();
+        window.cshToast && window.cshToast.show(
+            'Salesforce session not available. Please reload the page.',
+            { type: 'error' }
+        );
+        return;
+    }
     chrome.runtime.sendMessage({
             "oauth": "connectToLocal",
-            "sessionId": sessionId,
+            "sessionId": sid,
             "serverUrl": serverUrl
     }, function (response) {
         chrome.runtime.sendMessage({
@@ -47,6 +56,7 @@ function downloadPackage() {
                 }
             });
     } );
+    }); // end window.cshSession.ready.then
 }
 
 function setDownloading() {
@@ -59,9 +69,9 @@ function unSetDownloading() {
     $("#downloadButton").prop('disabled', false);
 }
 
-if (!sessionId) {
-    $('.bDescription').append('<span style="background-color:yellow"><strong><br/> <br/>Sorry, currently for the Change Set Helper to work, please UNSET the Require HTTPOnly Attribute checkbox in Security -> Session Settings. Then logout and back in again.  </strong></span>')
-} else {
+var changename;
+
+function cshRenderMetadataHelper() {
     $('.bDescription').append(`
     <div class='apexp'>
 	<div class="bPageBlock brandSecondaryBrd apexDefaultPageBlock secondaryPalette">
@@ -73,16 +83,38 @@ if (!sessionId) {
 	<td class="pbTitle"><h2 class="mainTitle">Metadata Helper</h2></td>
 	<td class="pbButton">
         <input id="downloadButton" value="Download metadata" class="btn" name="downloadall" title="Download all items in changeset for use in ant" type="button" />
-	&nbsp; Download metadata as zip package. 
+	&nbsp; Download metadata as zip package.
 	</td>
 	</tr>
 	</tbody>
 	</table>
 	</div>  `
-    )
-
+    );
     $("#downloadButton").click(downloadPackage);
-    var changename = $('h2.pageDescription').text();
+    changename = $('h2.pageDescription').text();
 }
+
+(function () {
+    function renderFallbackWarning() {
+        $('.bDescription').append(
+            '<span style="background-color:yellow"><strong><br/> <br/>' +
+            'The Change Set Helper could not read the Salesforce session cookie. ' +
+            'Either grant the extension the "cookies" permission (usually automatic) ' +
+            'or uncheck Setup → Session Settings → Require HttpOnly attribute.' +
+            '</strong></span>'
+        );
+    }
+
+    if (window.cshSession && window.cshSession.ready) {
+        window.cshSession.ready.then(function (sid) {
+            if (sid) cshRenderMetadataHelper();
+            else renderFallbackWarning();
+        });
+    } else if (sessionId) {
+        cshRenderMetadataHelper();
+    } else {
+        renderFallbackWarning();
+    }
+})();
 
 


### PR DESCRIPTION
## Summary

Removes the hard \"you must uncheck Require HttpOnly\" prerequisite.

- **manifest.json** — adds \`cookies\` permission; broadens \`host_permissions\` to the full Salesforce domain surface (\`salesforce.com\`, \`force.com\`, \`cloudforce.com\`, \`salesforce-setup.com\`).
- **common.js** — exposes \`window.cshSession.ready\` Promise. Fast-path synchronous \`document.cookie\` read; on miss, falls back to a service-worker \`chrome.cookies.get\` call that sees HttpOnly cookies.
- **background.js** — \`getSessionCookie\` handler, cookieStoreId-aware.
- **changeset.js / deployhelper.js / metadatahelper.js** — every entry point that needed the sid now awaits \`cshSession.ready\` before sending \`connectToLocal\`. The legacy yellow \"please uncheck HttpOnly\" banner only renders after the async fallback has failed.
- **README.md** — notes HttpOnly-off is no longer required; workaround kept for orgs that block the cookies permission.

## Stacked on #10

Targets \`phase-2-coverage\`. Deferring Phase 2.3 (Tooling-API SourceMember speed-up) since it's optimization-only; we can revisit after Phase 3 ships.

## Test plan

- [ ] Fresh install on an org with \"Require HttpOnly attribute\" **enabled**:
  - [ ] Extension loads, no yellow banner.
  - [ ] Component-type selection populates last-modified columns normally.
  - [ ] DevTools console shows a \`getSessionCookie\` message round-trip.
- [ ] Org with HttpOnly **disabled** (legacy path):
  - [ ] Still works, no regressions.
- [ ] Extension without cookies permission granted (shouldn't happen by default but worth simulating):
  - [ ] Yellow banner appears only after the background fallback failed.
- [ ] Download-as-ZIP on Outbound Change Set Detail still works.
- [ ] Validate / Quick-Deploy on Outbound Change Set Detail still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)