### PR TITLE
Phase 4: OAuth refresh-token fallback in cshSession ladder

### DIFF
--- a/background.js
+++ b/background.js
@@ -83,6 +83,153 @@ function buildAuthUrl(environment) {
         '&redirect_uri=' + encodeURIComponent(redirectUri);
 }
 
+// ---------------------------------------------------------------------------
+// OAuth code + PKCE helpers — Phase 4 refresh-token auth fallback.
+//
+// Data path: when the content script's cshSession.ready cannot obtain a sid
+// via document.cookie or chrome.cookies.get, it asks the service worker for
+// an OAuth access token. We look up a stored {access_token, refresh_token}
+// per host in chrome.storage.local, refresh if stale, and either return the
+// token or a 'needs-login' signal so the content script can show a
+// "Sign in via OAuth" button which triggers cshAuthLogin.
+// ---------------------------------------------------------------------------
+
+var TOKEN_STORE_KEY = 'cshOauthTokens';
+var TOKEN_STALE_MS = 90 * 60 * 1000; // 90 min — Salesforce access tokens usually live 1-2h
+
+function cshB64Url(bytes) {
+    var str = '';
+    for (var i = 0; i < bytes.length; i++) str += String.fromCharCode(bytes[i]);
+    return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+async function cshGeneratePkce() {
+    var rand = new Uint8Array(32);
+    crypto.getRandomValues(rand);
+    var verifier = cshB64Url(rand);
+    var hash = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier));
+    var challenge = cshB64Url(new Uint8Array(hash));
+    return { verifier: verifier, challenge: challenge };
+}
+
+function cshReadTokens() {
+    return new Promise(function (resolve) {
+        chrome.storage.local.get([TOKEN_STORE_KEY], function (items) {
+            resolve((items && items[TOKEN_STORE_KEY]) || {});
+        });
+    });
+}
+
+function cshWriteTokens(all) {
+    return new Promise(function (resolve) {
+        chrome.storage.local.set({ [TOKEN_STORE_KEY]: all }, function () { resolve(); });
+    });
+}
+
+async function cshGetTokenForHost(host) {
+    var all = await cshReadTokens();
+    return all[host] || null;
+}
+
+async function cshSaveTokenForHost(host, token) {
+    var all = await cshReadTokens();
+    all[host] = Object.assign({}, token, { host: host, savedAt: Date.now() });
+    await cshWriteTokens(all);
+}
+
+async function cshClearTokenForHost(host) {
+    var all = await cshReadTokens();
+    delete all[host];
+    await cshWriteTokens(all);
+}
+
+function cshHostFromUrl(urlStr) {
+    try {
+        var u = new URL(urlStr);
+        return u.protocol + '//' + u.host;
+    } catch (_) { return null; }
+}
+
+async function cshExchangeCodeForToken(host, code, codeVerifier) {
+    var body = new URLSearchParams();
+    body.append('grant_type', 'authorization_code');
+    body.append('code', code);
+    body.append('redirect_uri', redirectUri);
+    body.append('client_id', cshClientId);
+    body.append('code_verifier', codeVerifier);
+    var resp = await fetch(host + '/services/oauth2/token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: body.toString()
+    });
+    var json = await resp.json();
+    if (!resp.ok || !json.access_token) {
+        throw new Error(json.error_description || json.error || 'Token exchange failed (HTTP ' + resp.status + ')');
+    }
+    return {
+        accessToken: json.access_token,
+        refreshToken: json.refresh_token || null,
+        instanceUrl: json.instance_url || host,
+        issuedAt: parseInt(json.issued_at, 10) || Date.now(),
+        scope: json.scope || ''
+    };
+}
+
+async function cshRefreshAccessToken(host, refreshToken) {
+    var body = new URLSearchParams();
+    body.append('grant_type', 'refresh_token');
+    body.append('client_id', cshClientId);
+    body.append('refresh_token', refreshToken);
+    var resp = await fetch(host + '/services/oauth2/token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: body.toString()
+    });
+    var json = await resp.json();
+    if (!resp.ok || !json.access_token) {
+        throw new Error(json.error_description || json.error || 'Refresh failed (HTTP ' + resp.status + ')');
+    }
+    return {
+        accessToken: json.access_token,
+        refreshToken: json.refresh_token || refreshToken, // Salesforce may or may not rotate
+        instanceUrl: json.instance_url || host,
+        issuedAt: parseInt(json.issued_at, 10) || Date.now(),
+        scope: json.scope || ''
+    };
+}
+
+async function cshRunOauthLogin(host) {
+    var pkce = await cshGeneratePkce();
+    var state = Math.random().toString(36).slice(2);
+    var authUrl = host + '/services/oauth2/authorize' +
+        '?response_type=code' +
+        '&client_id=' + encodeURIComponent(cshClientId) +
+        '&redirect_uri=' + encodeURIComponent(redirectUri) +
+        '&scope=' + encodeURIComponent('api refresh_token id') +
+        '&code_challenge=' + encodeURIComponent(pkce.challenge) +
+        '&code_challenge_method=S256' +
+        '&state=' + state;
+    var redirectUrl = await new Promise(function (resolve, reject) {
+        chrome.identity.launchWebAuthFlow(
+            { url: authUrl, interactive: true },
+            function (url) {
+                if (chrome.runtime.lastError) return reject(new Error(chrome.runtime.lastError.message));
+                if (!url) return reject(new Error('No redirect URL returned'));
+                resolve(url);
+            }
+        );
+    });
+    var u = new URL(redirectUrl);
+    var params = new URLSearchParams(u.search);
+    if (params.get('error')) {
+        throw new Error(params.get('error') + (params.get('error_description') ? ': ' + params.get('error_description') : ''));
+    }
+    var code = params.get('code');
+    if (!code) throw new Error('No authorization code in redirect');
+    if (params.get('state') !== state) throw new Error('OAuth state mismatch — aborting');
+    return await cshExchangeCodeForToken(host, code, pkce.verifier);
+}
+
 // Keep service worker alive during long-running operations
 let keepAliveInterval = null;
 
@@ -276,6 +423,85 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
         return true;
     }
 
+    if (request.type == "cshAuthLogin") {
+        var loginHost = request.host || cshHostFromUrl(sender && sender.tab && sender.tab.url);
+        if (!loginHost) {
+            sendResponse({ ok: false, error: 'Unknown target host for OAuth login' });
+            return false;
+        }
+        cshRunOauthLogin(loginHost)
+            .then(function (tokens) {
+                return cshSaveTokenForHost(loginHost, tokens).then(function () {
+                    sendResponse({
+                        ok: true,
+                        accessToken: tokens.accessToken,
+                        instanceUrl: tokens.instanceUrl,
+                        hasRefreshToken: !!tokens.refreshToken,
+                        scope: tokens.scope
+                    });
+                });
+            })
+            .catch(function (err) {
+                console.error('cshAuthLogin failed:', err);
+                sendResponse({ ok: false, error: err.message });
+            });
+        return true;
+    }
+
+    if (request.type == "cshAuthGetToken") {
+        var getHost = request.host || cshHostFromUrl(sender && sender.tab && sender.tab.url);
+        if (!getHost) {
+            sendResponse({ ok: false, reason: 'no-host' });
+            return false;
+        }
+        (async function () {
+            try {
+                var stored = await cshGetTokenForHost(getHost);
+                if (!stored) { sendResponse({ ok: false, reason: 'no-token' }); return; }
+                var age = Date.now() - (stored.issuedAt || stored.savedAt || 0);
+                // If we have a refresh token and the access token is stale
+                // (or the caller explicitly asked for a fresh one), refresh.
+                if (stored.refreshToken && (age > TOKEN_STALE_MS || request.forceRefresh)) {
+                    try {
+                        var refreshed = await cshRefreshAccessToken(getHost, stored.refreshToken);
+                        await cshSaveTokenForHost(getHost, refreshed);
+                        sendResponse({
+                            ok: true,
+                            accessToken: refreshed.accessToken,
+                            instanceUrl: refreshed.instanceUrl,
+                            refreshed: true
+                        });
+                        return;
+                    } catch (e) {
+                        console.warn('cshAuthGetToken: refresh failed, returning stored token', e.message);
+                        // Fall through to the stored (possibly stale) token;
+                        // the caller will surface "please sign in again" if SF 401s.
+                    }
+                }
+                sendResponse({
+                    ok: true,
+                    accessToken: stored.accessToken,
+                    instanceUrl: stored.instanceUrl,
+                    refreshed: false,
+                    ageMs: age
+                });
+            } catch (err) {
+                sendResponse({ ok: false, error: err.message });
+            }
+        })();
+        return true;
+    }
+
+    if (request.type == "cshAuthLogout") {
+        var logoutHost = request.host || cshHostFromUrl(sender && sender.tab && sender.tab.url);
+        if (!logoutHost) {
+            sendResponse({ ok: false, reason: 'no-host' });
+            return false;
+        }
+        cshClearTokenForHost(logoutHost).then(function () { sendResponse({ ok: true }); });
+        return true;
+    }
+
     if (request.type == "cshCartSubmit") {
         // Cart worker batch submission: POST to the native Add-Components
         // endpoint using the scraped form shape, with our chosen ids replacing
@@ -369,7 +595,13 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
     }
 
     if (request.oauth == "connectToLocal") {
-        setLocalConn(sendResponse, request.sessionId, request.serverUrl);
+        setLocalConn(
+            sendResponse,
+            request.sessionId,
+            request.serverUrl,
+            request.authMode || 'sid',
+            request.instanceUrl || request.serverUrl
+        );
         return true;
     }
 
@@ -477,12 +709,15 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
     }
 });
 
-async function setLocalConn(sendResponse, sessionId, serverUrl) {
+async function setLocalConn(sendResponse, authValue, serverUrl, authMode, instanceUrl) {
     try {
         await sendToOffscreen({
             action: 'setLocalConn',
-            sessionId: sessionId,
-            serverUrl: serverUrl
+            sessionId: authValue,       // kept for legacy — offscreen decides by authMode
+            authValue: authValue,
+            authMode: authMode || 'sid',
+            serverUrl: serverUrl,
+            instanceUrl: instanceUrl || serverUrl
         });
         sendResponse();
     } catch (err) {

--- a/changeset.js
+++ b/changeset.js
@@ -1151,11 +1151,15 @@ function runEnhancedFlow() {
             $("#bodyCell").removeClass("changesetloading");
             return;
         }
-        // Fetch metadata FIRST
+        // Fetch metadata FIRST. Pass the chosen auth mode so offscreen uses
+        // the right jsforce.Connection shape (sessionId+serverUrl vs
+        // accessToken+instanceUrl).
         chrome.runtime.sendMessage({
             "oauth": "connectToLocal",
             "sessionId": sid,
-            "serverUrl": serverUrl
+            "serverUrl": serverUrl,
+            "authMode": window.cshSession.mode ? window.cshSession.mode() : 'sid',
+            "instanceUrl": window.cshSession.instanceUrl ? window.cshSession.instanceUrl() : serverUrl
         }, function (response) {
         // Check for Chrome runtime errors only
         if (chrome.runtime.lastError) {
@@ -1505,7 +1509,9 @@ function startMetadataLoading() {
             chrome.runtime.sendMessage({
                 "oauth": "connectToLocal",
                 "sessionId": sid,
-                "serverUrl": serverUrl
+                "serverUrl": serverUrl,
+                "authMode": window.cshSession.mode ? window.cshSession.mode() : 'sid',
+                "instanceUrl": window.cshSession.instanceUrl ? window.cshSession.instanceUrl() : serverUrl
             }, function (response) {
                 console.log('Fetching metadata to determine table columns for type:', selectedEntityType);
                 getMetaData(processListResults);
@@ -1554,20 +1560,44 @@ $(document).ready(function () {
 
     $('input[name="cancel"]').parent().on('click','#compareorg' , oauthLogin);
 
-    // Only warn about HttpOnly after the cookies-API fallback has had a chance
-    // to resolve — on HttpOnly-on orgs the fast-path read fails but the
-    // background can still retrieve the session via chrome.cookies.get.
+    // Three-stage auth ladder: cookie → chrome.cookies → OAuth. If all three
+    // fail, show an actionable Sign In button that triggers the OAuth PKCE
+    // flow in a popup. Success reloads the page so the new token is picked
+    // up by cshSession.ready on next init.
     if (window.cshSession && window.cshSession.ready) {
         window.cshSession.ready.then(function (sid) {
-            if (!sid) {
-                $('.bDescription').append(
-                    '<span style="background-color:yellow"><strong><br/> <br/>' +
-                    'The Change Set Helper could not read the Salesforce session cookie. ' +
-                    'Either grant the extension the "cookies" permission (usually automatic) ' +
-                    'or uncheck Setup → Session Settings → Require HttpOnly attribute.' +
-                    '</strong></span>'
-                );
-            }
+            if (sid) return;
+            var banner = $(
+                '<div id="csh-signin-banner" style="background:#fff5d6;border:1px solid #d1c083;border-radius:4px;padding:12px 14px;margin:10px 0;display:flex;gap:10px;align-items:center;">' +
+                '<div style="flex:1 1 auto;">' +
+                  '<strong>Change Set Helper needs to sign in.</strong><br/>' +
+                  'Your Salesforce session cookie is not readable from this browser. ' +
+                  'Sign in via OAuth to let the extension call the Metadata API on your behalf. ' +
+                  'You can alternatively uncheck Setup → Session Settings → Require HttpOnly attribute.' +
+                '</div>' +
+                '<button id="csh-signin-btn" style="flex:0 0 auto;padding:8px 14px;background:#0176d3;color:#fff;border:0;border-radius:3px;cursor:pointer;font:inherit;font-weight:600;">Sign in via OAuth</button>' +
+                '</div>'
+            );
+            $('.bDescription').append(banner);
+            banner.find('#csh-signin-btn').on('click', async function () {
+                var btn = $(this);
+                btn.prop('disabled', true).text('Opening popup…');
+                var resp = await window.cshAuth.login();
+                if (resp && resp.ok && resp.accessToken) {
+                    window.cshToast && window.cshToast.show(
+                        'Signed in. Reloading to pick up the new session…',
+                        { type: 'success', duration: 2000 }
+                    );
+                    setTimeout(function () { location.reload(); }, 600);
+                } else {
+                    btn.prop('disabled', false).text('Sign in via OAuth');
+                    window.cshToast && window.cshToast.show(
+                        'Sign in failed: ' + ((resp && resp.error) || 'unknown error') +
+                        '. Use Options → OAuth Diagnostic to troubleshoot.',
+                        { type: 'error' }
+                    );
+                }
+            });
         });
     } else if (!sessionId) {
         $('.bDescription').append(

--- a/common.js
+++ b/common.js
@@ -37,6 +37,19 @@ var sessionId = (function () {
 var serverUrl = window.location.protocol + '//' + window.location.host;
 
 window.cshSession = (function () {
+    // Auth ladder:
+    //   1. document.cookie    (fast path, works when HttpOnly is off)
+    //   2. chrome.cookies.get (Phase 2.4, works even with HttpOnly on)
+    //   3. OAuth access token (Phase 4, runs when cookies are unavailable)
+    // Every Promise step resolves to an auth value (sid OR accessToken) or
+    // null when nothing is usable; final `null` triggers the content script's
+    // "Sign in via OAuth" banner.
+    var state = {
+        mode: sessionId ? 'sid' : null,
+        instanceUrl: serverUrl,
+        oauthRefreshed: false
+    };
+
     function askBackgroundForCookie() {
         return new Promise(function (resolve) {
             if (!chrome || !chrome.runtime || !chrome.runtime.sendMessage) return resolve(null);
@@ -48,7 +61,8 @@ window.cshSession = (function () {
                         return resolve(null);
                     }
                     if (response && response.sid) {
-                        sessionId = response.sid; // update module-scoped var so legacy callers see it
+                        sessionId = response.sid;
+                        state.mode = 'sid';
                         return resolve(response.sid);
                     }
                     resolve(null);
@@ -57,13 +71,92 @@ window.cshSession = (function () {
         });
     }
 
-    var readyPromise = sessionId ? Promise.resolve(sessionId) : askBackgroundForCookie();
+    function askBackgroundForOauthToken() {
+        return new Promise(function (resolve) {
+            if (!chrome || !chrome.runtime || !chrome.runtime.sendMessage) return resolve(null);
+            chrome.runtime.sendMessage(
+                { type: 'cshAuthGetToken', host: serverUrl },
+                function (response) {
+                    if (chrome.runtime.lastError) {
+                        console.warn('cshSession: OAuth fallback errored:', chrome.runtime.lastError.message);
+                        return resolve(null);
+                    }
+                    if (response && response.ok && response.accessToken) {
+                        sessionId = response.accessToken;
+                        state.mode = 'oauth';
+                        state.instanceUrl = response.instanceUrl || serverUrl;
+                        state.oauthRefreshed = !!response.refreshed;
+                        return resolve(response.accessToken);
+                    }
+                    resolve(null);
+                }
+            );
+        });
+    }
+
+    var readyPromise = sessionId
+        ? Promise.resolve(sessionId)
+        : askBackgroundForCookie().then(function (cookieSid) {
+            if (cookieSid) return cookieSid;
+            return askBackgroundForOauthToken();
+        });
 
     return {
         ready: readyPromise,
-        // Returns the current session id synchronously; may be null until
-        // ready resolves on HttpOnly-on orgs.
-        current: function () { return sessionId; }
+        // Returns the current session value synchronously; may be null until
+        // ready resolves. Works for sid and OAuth access-token modes alike.
+        current: function () { return sessionId; },
+        // 'sid' | 'oauth' | null — tells downstream connect() calls which
+        // JSforce configuration to use (sessionId+serverUrl vs accessToken+instanceUrl).
+        mode: function () { return state.mode; },
+        instanceUrl: function () { return state.instanceUrl; }
+    };
+})();
+
+// Phase 4: cshAuth — thin wrapper over the service worker's OAuth helpers.
+//   login()    -> launches PKCE flow, stores {accessToken, refreshToken}
+//   logout()   -> clears stored tokens for this host
+//   getAccessToken({forceRefresh}) -> returns fresh access token (may refresh)
+// All round-trip to chrome.runtime.sendMessage so interactive browser
+// auth (chrome.identity.launchWebAuthFlow) happens in the correct context.
+window.cshAuth = (function () {
+    function callBackground(payload) {
+        return new Promise(function (resolve) {
+            if (!chrome || !chrome.runtime || !chrome.runtime.sendMessage) return resolve({ ok: false, error: 'No chrome.runtime' });
+            chrome.runtime.sendMessage(payload, function (response) {
+                if (chrome.runtime.lastError) return resolve({ ok: false, error: chrome.runtime.lastError.message });
+                resolve(response || { ok: false, error: 'No response' });
+            });
+        });
+    }
+
+    async function login() {
+        var resp = await callBackground({ type: 'cshAuthLogin', host: serverUrl });
+        if (resp && resp.ok && resp.accessToken) {
+            sessionId = resp.accessToken; // propagate so legacy readers see it
+        }
+        return resp;
+    }
+
+    async function logout() {
+        var resp = await callBackground({ type: 'cshAuthLogout', host: serverUrl });
+        return resp;
+    }
+
+    async function getAccessToken(opts) {
+        opts = opts || {};
+        var resp = await callBackground({
+            type: 'cshAuthGetToken',
+            host: serverUrl,
+            forceRefresh: !!opts.forceRefresh
+        });
+        return resp;
+    }
+
+    return {
+        login: login,
+        logout: logout,
+        getAccessToken: getAccessToken
     };
 })();
 

--- a/metadatahelper.js
+++ b/metadatahelper.js
@@ -96,13 +96,30 @@ function cshRenderMetadataHelper() {
 
 (function () {
     function renderFallbackWarning() {
-        $('.bDescription').append(
-            '<span style="background-color:yellow"><strong><br/> <br/>' +
-            'The Change Set Helper could not read the Salesforce session cookie. ' +
-            'Either grant the extension the "cookies" permission (usually automatic) ' +
-            'or uncheck Setup → Session Settings → Require HttpOnly attribute.' +
-            '</strong></span>'
+        var banner = $(
+            '<div id="csh-signin-banner-md" style="background:#fff5d6;border:1px solid #d1c083;border-radius:4px;padding:12px 14px;margin:10px 0;display:flex;gap:10px;align-items:center;">' +
+            '<div style="flex:1 1 auto;">' +
+              '<strong>Change Set Helper needs to sign in.</strong><br/>' +
+              'Your Salesforce session cookie is not readable. Sign in via OAuth to enable the metadata download.' +
+            '</div>' +
+            '<button id="csh-signin-btn-md" style="flex:0 0 auto;padding:8px 14px;background:#0176d3;color:#fff;border:0;border-radius:3px;cursor:pointer;font:inherit;font-weight:600;">Sign in via OAuth</button>' +
+            '</div>'
         );
+        $('.bDescription').append(banner);
+        banner.find('#csh-signin-btn-md').on('click', async function () {
+            var btn = $(this);
+            btn.prop('disabled', true).text('Opening popup…');
+            var resp = window.cshAuth ? await window.cshAuth.login() : null;
+            if (resp && resp.ok && resp.accessToken) {
+                setTimeout(function () { location.reload(); }, 600);
+            } else {
+                btn.prop('disabled', false).text('Sign in via OAuth');
+                window.cshToast && window.cshToast.show(
+                    'Sign in failed: ' + ((resp && resp.error) || 'unknown error'),
+                    { type: 'error' }
+                );
+            }
+        });
     }
 
     if (window.cshSession && window.cshSession.ready) {

--- a/offscreen.js
+++ b/offscreen.js
@@ -100,7 +100,12 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 
     switch(request.action) {
         case 'setLocalConn':
-            setLocalConn(request.sessionId, request.serverUrl);
+            setLocalConn(
+                request.authValue || request.sessionId,
+                request.serverUrl,
+                request.authMode || 'sid',
+                request.instanceUrl || request.serverUrl
+            );
             sendResponse({success: true});
             break;
 
@@ -170,14 +175,22 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     }
 });
 
-function setLocalConn(sessionId, serverUrl) {
-    connLocal.conn = new jsforce.Connection({
-        'serverUrl': serverUrl,
-        'sessionId': sessionId,
-        'version': CSH_APIVERSION
-    });
+function setLocalConn(authValue, serverUrl, authMode, instanceUrl) {
+    // Two accepted auth shapes:
+    //   authMode = 'sid'   -> serverUrl + sessionId  (from browser cookie)
+    //   authMode = 'oauth' -> instanceUrl + accessToken  (from PKCE login)
+    var opts = { 'version': CSH_APIVERSION };
+    if (authMode === 'oauth') {
+        opts.instanceUrl = instanceUrl || serverUrl;
+        opts.accessToken = authValue;
+    } else {
+        opts.serverUrl = serverUrl;
+        opts.sessionId = authValue;
+    }
+    connLocal.conn = new jsforce.Connection(opts);
     connLocal.conn.metadata.pollTimeout = POLLTIMEOUT;
     connLocal.conn.metadata.pollInterval = POLLINTERVAL;
+    console.log('setLocalConn: authMode =', authMode || 'sid', ', host =', (opts.instanceUrl || opts.serverUrl));
 }
 
 async function connectToOrg(environment, connType, instanceUrl, accessToken) {


### PR DESCRIPTION
## Summary

Completes the OAuth story started by the diagnostic in PR #13. Sessions now resolve via a three-step ladder:

1. \`document.cookie\` sid (fast path)
2. \`chrome.cookies.get\` sid (Phase 2.4 — works with HttpOnly on)
3. **OAuth access token from chrome.storage.local** (new in this PR — no session cookie needed at all)

When all three return null, the content script shows an inline **"Sign in via OAuth"** banner in place of the legacy yellow "disable HttpOnly" warning. One click launches the PKCE popup; on success we reload the page and the extension proceeds with the new token.

## Architecture

### background.js
Added standalone token-lifecycle helpers (no external deps):
- \`cshGeneratePkce()\` — SHA-256 via \`crypto.subtle\`, base64url-encoded
- \`cshRunOauthLogin(host)\` — launchWebAuthFlow + state validation + token exchange
- \`cshRefreshAccessToken(host, refresh)\` — honors Salesforce rotating the refresh token
- \`cshReadTokens / cshWriteTokens\` — per-host bag in \`chrome.storage.local.cshOauthTokens\`
- \`cshGetTokenForHost / cshSaveTokenForHost / cshClearTokenForHost\`

Three new runtime messages:
- \`cshAuthLogin\` — interactive login, stores and returns the token
- \`cshAuthGetToken\` — returns cached token; auto-refreshes if older than 90 min (\`TOKEN_STALE_MS\`) or when \`forceRefresh: true\`
- \`cshAuthLogout\` — clears stored tokens for the host

\`setLocalConn\` now carries \`authMode\` + \`instanceUrl\` through to the offscreen document so the right jsforce.Connection shape is constructed.

### common.js
\`cshSession.ready\` now chains:
\`\`\`js
sessionId || askBackgroundForCookie().then(c => c || askBackgroundForOauthToken())
\`\`\`
Exposes \`cshSession.mode()\` → \`'sid' | 'oauth' | null\` and \`cshSession.instanceUrl()\` so downstream callers pick the right JSforce shape.

New \`window.cshAuth\` wrapper (login / logout / getAccessToken) — content scripts stay free of \`chrome.identity\` and crypto plumbing.

### offscreen.js
\`setLocalConn\` accepts either auth shape:
- \`authMode: 'sid'\` → \`new jsforce.Connection({ serverUrl, sessionId })\`
- \`authMode: 'oauth'\` → \`new jsforce.Connection({ instanceUrl, accessToken })\`

### changeset.js
- Both \`connectToLocal\` call-sites pass \`authMode\` + \`instanceUrl\`.
- Yellow HttpOnly warning is replaced by a styled Sign-In banner that opens \`cshAuth.login()\` and reloads on success.

### metadatahelper.js
- Same Sign-In banner on the Outbound Change Set Detail page.

## Compatibility with PR #13 Connected App

The Connected App deployed in PR #13 (\`Api + Basic + RefreshToken\` scopes, \`isConsumerSecretOptional=true\`, PKCE-ready) handles all three flows exposed by this PR:

| Flow | Uses |
|---|---|
| Cart submit / metadata list | Session cookie OR OAuth accessToken via \`Api\` scope |
| Compare-with-org | Implicit grant (\`response_type=token\`) — accepted due to \`isConsumerSecretOptional\` |
| Validate / Quick-Deploy | Same connection as Compare |
| OAuth fallback (this PR) | Code + PKCE + \`RefreshToken\` scope |

## Test plan

- [ ] Reload extension. Confirm compare-with-org still works (regression test on the existing session-cookie path).
- [ ] **Simulate cookie loss**: DevTools → Application → Cookies → delete the sid cookie for the Salesforce domain → reload the Add Components page → expect:
  - Yellow sign-in banner renders (not the legacy disable-HttpOnly warning).
  - Clicking Sign in via OAuth opens the popup.
  - After approval, page reloads and metadata columns populate normally.
- [ ] **Check token persistence**: close the tab, reopen a Change Sets page on the same org → no prompt, extension works directly (token reused from \`chrome.storage.local\`).
- [ ] **Force token expiry**: in DevTools → Application → chrome.storage.local → cshOauthTokens → edit \`issuedAt\` to (Date.now() − 5 * 3600 * 1000) → reload → expect a silent refresh (check Network tab for \`/services/oauth2/token\` with \`grant_type=refresh_token\`).
- [ ] **Revoke refresh**: Setup → Session Management → revoke the \`Change Set Helper\` session → reload the page → refresh fails → sign-in banner appears again.
- [ ] **Cross-tab consistency**: two Setup tabs open → sign in on one → the other tab's banner should disappear on its next reload because the token is in shared \`chrome.storage.local\`.

## Known limitations (deferred to future phases)

- **No 401 interception.** If the access token expires mid-session (between the 90-min staleness check and the next API call), the JSforce call returns a 401 and the toast says "please sign in again". A proper fix requires a request interceptor in the offscreen doc — non-trivial and non-critical; users can just click Sign in again.
- **Implicit grant path (compare-with-org) does not yet use the new token store.** It still does its own launchWebAuthFlow per click. Unifying the two paths is a cleanup task.
- **Connected App's \`OAuth Policies → IP Relaxation\`** must be \`Relax IP restrictions\` for PR #13's deployed app to allow logins from any network. Deploy via Metadata API doesn't set this reliably on first deploy — verify manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)