### PR TITLE
v3.1.1: Lightning iframe + Setup-domain cart sync fixes

### DIFF
--- a/background.js
+++ b/background.js
@@ -927,6 +927,45 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
         return true;
     }
 
+    if (request.type == "cshClassicFetch") {
+        // Content-script proxy for credentialed GETs of classic Salesforce
+        // pages. Content scripts running on *.my.salesforce-setup.com can't
+        // fetch *.my.salesforce.com with credentials: the two domains are
+        // different eTLDs under the public suffix list, so the browser blocks
+        // the cross-origin cookie request and the content-script fetch throws
+        // "Failed to fetch". The service worker has host_permissions for both
+        // domains, so it can cross the boundary and send the sid cookie for
+        // the target origin. Used by cart.js syncFromChangeSetView to scrape
+        // /<id>?tab=PackageComponents on Setup-domain orgs.
+        (async function () {
+            try {
+                if (!request.url) {
+                    sendResponse({ ok: false, error: 'cshClassicFetch: url required' });
+                    return;
+                }
+                var resp = await fetch(request.url, {
+                    method: 'GET',
+                    credentials: 'include',
+                    // X-Requested-With avoids Salesforce interstitials that
+                    // sometimes wrap plain browser navigations; the classic
+                    // component list page returns the same HTML either way.
+                    headers: { 'X-Requested-With': 'XMLHttpRequest' }
+                });
+                var text = await resp.text();
+                sendResponse({
+                    ok: resp.ok,
+                    status: resp.status,
+                    finalUrl: resp.url,
+                    text: text
+                });
+            } catch (err) {
+                console.error('cshClassicFetch failed:', err);
+                sendResponse({ ok: false, error: err.message || String(err) });
+            }
+        })();
+        return true;
+    }
+
     if (request.type == "cshCartSubmit") {
         // Cart worker batch submission: POST to the native Add-Components
         // endpoint using the scraped form shape, with our chosen ids replacing

--- a/cart.js
+++ b/cart.js
@@ -1283,17 +1283,71 @@
         }
         return null;
     }
+    // Salesforce's 2024 domain split serves Setup pages (including
+    // AddToPackageFromChangeMgmtUi) from *.my.salesforce-setup.com and the
+    // rest of the app — including outbound change-set detail pages and their
+    // ?tab=PackageComponents view — from *.my.salesforce.com. Cookies don't
+    // cross those eTLDs, so a `credentials:'include'` fetch built against
+    // location.href on a Setup page hits the wrong origin for this URL and
+    // Salesforce returns a Lightning shell / login page with no tr.dataRow.
+    // Translating just the host back to my.salesforce.com keeps the rest of
+    // the URL (path, query) intact and ships the right cookies.
+    function _appOriginForChangeSetView() {
+        var host = location.host || '';
+        if (/\.my\.salesforce-setup\.com$/i.test(host)) {
+            return location.protocol + '//' + host.replace(/\.my\.salesforce-setup\.com$/i, '.my.salesforce.com');
+        }
+        return location.origin;
+    }
+    // Cross-origin credentialed fetches from content scripts are blocked by
+    // Chrome even when the extension declares host_permissions for both
+    // domains. The service worker doesn't have that limitation, so we proxy
+    // through it via cshClassicFetch (background.js). Returns the same shape
+    // a raw fetch+text() would produce: { ok, status, url, text }. Same-origin
+    // fetches still go direct to avoid an unnecessary SW round trip on legacy
+    // *.my.salesforce.com orgs.
+    function _fetchClassicPage(url) {
+        var sameOrigin = (function () {
+            try { return new URL(url).origin === location.origin; }
+            catch (_) { return false; }
+        })();
+        if (sameOrigin) {
+            return fetch(url, { credentials: 'include' }).then(function (r) {
+                return r.text().then(function (text) {
+                    return { ok: r.ok, status: r.status, url: r.url, text: text };
+                });
+            });
+        }
+        return new Promise(function (resolve, reject) {
+            chrome.runtime.sendMessage({ type: 'cshClassicFetch', url: url }, function (resp) {
+                if (chrome.runtime.lastError) {
+                    reject(new Error(chrome.runtime.lastError.message));
+                    return;
+                }
+                if (!resp) {
+                    reject(new Error('cshClassicFetch: no response from service worker'));
+                    return;
+                }
+                if (resp.error) {
+                    reject(new Error(resp.error));
+                    return;
+                }
+                resolve({ ok: resp.ok, status: resp.status, url: resp.finalUrl || url, text: resp.text || '' });
+            });
+        });
+    }
     async function syncFromChangeSetView(changeSetId, packageId) {
         if (!packageId) throw new Error('syncFromChangeSetView: packageId required');
         var items = [];
-        var nextUrl = new URL('/' + packageId + '?tab=PackageComponents&rowsperpage=5000', location.href).href;
+        var appOrigin = _appOriginForChangeSetView();
+        var nextUrl = new URL('/' + packageId + '?tab=PackageComponents&rowsperpage=5000', appOrigin).href;
         var safety = 200;
         var pageNum = 0;
         while (nextUrl && safety-- > 0) {
             pageNum++;
-            var r = await fetch(nextUrl, { credentials: 'include' });
+            var r = await _fetchClassicPage(nextUrl);
             if (!r.ok) throw new Error('HTTP ' + r.status + ' fetching classic components view');
-            var html = await r.text();
+            var html = r.text;
             var doc = new DOMParser().parseFromString(html, 'text/html');
             var table = doc.querySelector('table.list');
             if (!table) {
@@ -1343,6 +1397,23 @@
                 'dropped=', dropped, 'headerIdx=', idx);
             var nextHref = _findNextPageHrefInDoc(doc);
             nextUrl = nextHref ? new URL(nextHref, nextUrl).href : null;
+        }
+        // Zero scraped rows from a page that DID parse (table.list was found,
+        // else page-1 would have thrown above) means Salesforce served us a
+        // Lightning shell / unexpected layout, not a genuinely empty change
+        // set. Calling syncItemsFromServer with authoritative:true would be
+        // refused by its own defensive guard — skipping here keeps the log
+        // clean and avoids masking real work under a downstream warning.
+        // Callers see a zero-count summary and the preceding per-page log
+        // makes the cause (row dropped counts / headerIdx / shell response)
+        // easy to diagnose when it matters.
+        if (items.length === 0) {
+            console.warn('[CSH] Add-page authoritative sync: zero rows scraped from ' +
+                         new URL('/' + packageId + '?tab=PackageComponents&rowsperpage=5000', appOrigin).href +
+                         ' — skipping authoritative prune to preserve cart state. ' +
+                         'Likely causes: Lightning-shell response, wrong id kind (0A2 vs 033), ' +
+                         'or classic-DOM selectors not matching this org\'s rendered rows.');
+            return { count: 0, inserted: 0, promoted: 0, kept: 0, pruned: 0 };
         }
         // Write to every distinct key so both the Add page (033 MetadataPackage
         // id) and the Detail page (0A2 outbound change-set id) see the same

--- a/changeset.css
+++ b/changeset.css
@@ -93,14 +93,12 @@ table.list tr.csh-diff-same > td:first-child {
     padding: 3px 10px;
 }
 
-/* Hide Salesforce's alphabet quick-nav (A | B | C | ... | Other | All) from
-   the rolodex bar. The DataTables column-level search inputs we add to the
-   table footer supersede it, and leaving the alphabet visible just crowds
-   the row that now hosts the unified Actions group. */
-div.rolodex .listItem,
-div.rolodex .listItems {
-    display: none !important;
-}
+/* Leave Salesforce's native alphabet quick-nav (A | B | C | ... | Other |
+   All) visible on the rolodex bar. It lives alongside our toolbar actions
+   and provides a working fallback when the extension-enhanced table fails
+   to render (Lightning shell edge cases, cross-origin hiccups, etc.) —
+   users can still narrow the native rolodex by first letter and add
+   components the classic way. */
 
 /* Phase 7 — Detail page Components block: selection column + bulk remove
    + filter/search. Targets the inline components table on

--- a/changeset.js
+++ b/changeset.js
@@ -2413,19 +2413,41 @@ var ENABLE_PAGINATION_THRESHOLD = 1500; // Enable DataTables paging above this t
 // sibling VF origin — both the top frame AND those iframes match our
 // manifest pattern, so all_frames:true injects our content script in each
 // and we end up rendering multiple spinners / carts / toolbars. Detect the
-// nested-duplicate case via document.referrer and short-circuit everything.
-// Lightning's wrapper top-frame URL doesn't match our pattern, so iframes
-// there still initialise correctly.
+// sibling-nested case by reading the PARENT frame's URL and short-circuit
+// everything in that case.
+//
+// Why parent URL, not document.referrer: referrer reflects the previous
+// navigation within the SAME frame, not the embedding context. In Lightning
+// the Add page lives inside an iframe; when the user switches entity types
+// on the picker dropdown, the iframe re-navigates within itself. After the
+// switch, document.referrer becomes the *previous* AddToPackage URL, which
+// matched the old regex and made every post-switch navigation silently
+// skip init — users saw the extension disappear the moment they changed
+// picker selection in Lightning.
+//
+// Parent URL behaves correctly in both scenarios:
+//   - Classic sibling-iframe: parent IS the top Add page, same origin, the
+//     cross-frame read succeeds and matches the AddToPackage pattern → skip.
+//   - Lightning wrapper (Aura / Aloha): parent is a different eTLD (lightning
+//     .force.com, salesforce-setup.com, etc.), the read throws SecurityError,
+//     we catch it and treat ourselves as the primary iframe → run.
+// Top frame short-circuit stays: top is never a nested duplicate.
 var cshIsNestedDuplicate = (function () {
     if (window === window.top) return false;
     try {
-        var ref = document.referrer || '';
-        if (/\/p\/mfpkg\/AddToPackage(FromChangeMgmtUi|Ui)/i.test(ref)) {
-            console.log('csh: skipping init — nested frame whose parent is also AddToPackage');
+        var parentUrl = window.parent.location.href;
+        if (/\/p\/mfpkg\/AddToPackage(FromChangeMgmtUi|Ui)/i.test(parentUrl)) {
+            console.log('csh: skipping init — parent frame is also an AddToPackage page');
             return true;
         }
-    } catch (_) {}
-    return false;
+        // Same-origin parent that isn't AddToPackage — we're embedded by
+        // something unrelated; run normally.
+        return false;
+    } catch (_) {
+        // Cross-origin parent (Lightning shell, split-domain Setup wrapper,
+        // etc.) — we're the primary Add iframe, run normally.
+        return false;
+    }
 })();
 
 if (cshIsNestedDuplicate) {

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "manifest_version": 3,
   "name": "Salesforce Change Set Helper",
   "description": "Enhances the Salesforce change set. Adds last changed date and allows sorting, searching, validation and comparison with other orgs.",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "options_page": "options.html",
   "action": {
     "default_icon": "braincloudsmall.png",


### PR DESCRIPTION
## Summary

Fixes a regression where the extension silently stood down on the Add Components page in Lightning, plus the cart-sync breakage on orgs using the new Setup-only `*.my.salesforce-setup.com` domain. Also restores the native A-Z letter nav as a fallback when our enhanced table fails to render.

## Fixes

- **Lightning iframe false-positive.** The nested-duplicate check used `document.referrer`, which reflects prior navigation *within the same frame*. In Lightning, the Add page lives inside an iframe; every entity-type switch caused the new page's referrer to be the previous `AddToPackage*` URL, so `$(document).ready` wiring was skipped and the extension went dark. Switched to `window.parent.location.href` — same-origin read succeeds only in the true sibling-nested VF case, cross-origin reads (Lightning wrapper) throw `SecurityError` which we treat as "I'm the primary iframe."
- **Setup-domain cart sync.** Salesforce's 2024 domain split serves `AddToPackageFromChangeMgmtUi` from `*.my.salesforce-setup.com` but the classic `/<id>?tab=PackageComponents` view from `*.my.salesforce.com`. Cookies don't cross those eTLDs, so the authoritative cart scrape was hitting a Lightning shell / login page and yielding zero rows. Now translates the host back to the app domain before fetching.
- **Service-worker proxy for cross-origin credentialed fetch.** Content-script fetch can't cross the `salesforce-setup.com` ↔ `salesforce.com` boundary even with host_permissions for both. Added `cshClassicFetch` in `background.js` and routed the cart-sync GET through it.
- **Empty-items short-circuit.** `syncFromChangeSetView` now logs one clear warning and bails when the scrape yields zero rows, instead of calling `syncItemsFromServer` and relying on its defensive `refusing to authoritative-prune with empty input` log.
- **A-Z fallback.** Removed the CSS rule that hid the native alphabet quick-nav on the rolodex; it now renders next to our toolbar actions so users can still filter and add components if the enhanced table fails for any reason.

## Test plan

- [ ] Load the Add Components page directly on a classic `*.my.salesforce.com` org — toolbar renders, DataTables enhances, no duplicate toolbars.
- [ ] Load the Add Components page inside Lightning on a `*.my.salesforce-setup.com` sandbox — extension initializes, `Entity type resolution:` logs appear.
- [ ] Switch entity types repeatedly (Apex Class → Flow → Custom Field) inside Lightning — each switch reinitializes correctly, no "skipping init" misfires.
- [ ] Cart auto-populate on first Add-page visit with a populated change set on a Setup-domain org — either populates correctly (if the classic `?tab=PackageComponents` URL returns scrapable HTML) or emits the new explanatory "zero rows scraped" warning without wiping the cart.
- [ ] Confirm native A-Z letter nav is visible next to the Reset / Export / Import toolbar buttons.
- [ ] Confirm no `refusing to authoritative-prune with empty input` warning and no `Failed to fetch` from `changeset.js:3055`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)